### PR TITLE
Enable use of Raysect in interactive Jupyter notebooks

### DIFF
--- a/raysect/optical/observer/pipeline/bayer.pyx
+++ b/raysect/optical/observer/pipeline/bayer.pyx
@@ -402,7 +402,10 @@ cdef class BayerPipeline2D(Pipeline2D):
         self._render_display(self._display_frame, 'rendering...')
 
         # workaround for interactivity for QT backend
-        plt.pause(0.1)
+        try:
+            plt.pause(0.1)
+        except NotImplementedError:
+            pass
 
         self._display_timer = time()
 
@@ -430,7 +433,10 @@ cdef class BayerPipeline2D(Pipeline2D):
             self._render_display(self._display_frame, 'rendering...')
 
             # workaround for interactivity for QT backend
-            plt.pause(0.1)
+            try:
+                plt.pause(0.1)
+            except NotImplementedError:
+                pass
 
             self._display_timer = time()
 

--- a/raysect/optical/observer/pipeline/mono/power.pyx
+++ b/raysect/optical/observer/pipeline/mono/power.pyx
@@ -564,7 +564,10 @@ cdef class PowerPipeline2D(Pipeline2D):
         self._render_display(self._display_frame, 'rendering...')
 
         # workaround for interactivity for QT backend
-        plt.pause(0.1)
+        try:
+            plt.pause(0.1)
+        except NotImplementedError:
+            pass
 
         self._display_timer = time()
 
@@ -592,7 +595,10 @@ cdef class PowerPipeline2D(Pipeline2D):
             self._render_display(self._display_frame, 'rendering...')
 
             # workaround for interactivity for QT backend
-            plt.pause(0.1)
+            try:
+                plt.pause(0.1)
+            except NotImplementedError:
+                pass
 
             self._display_timer = time()
 

--- a/raysect/optical/observer/pipeline/rgb.pyx
+++ b/raysect/optical/observer/pipeline/rgb.pyx
@@ -304,7 +304,10 @@ cdef class RGBPipeline2D(Pipeline2D):
         self._render_display(self._display_frame, 'rendering...')
 
         # workaround for interactivity for QT backend
-        plt.pause(0.1)
+        try:
+            plt.pause(0.1)
+        except NotImplementedError:
+            pass
 
         self._display_timer = time()
 
@@ -334,7 +337,10 @@ cdef class RGBPipeline2D(Pipeline2D):
             self._render_display(self._display_frame, 'rendering...')
 
             # workaround for interactivity for QT backend
-            plt.pause(0.1)
+            try:
+                plt.pause(0.1)
+            except NotImplementedError:
+                pass
 
             self._display_timer = time()
 

--- a/raysect/optical/observer/pipeline/spectral/power.pyx
+++ b/raysect/optical/observer/pipeline/spectral/power.pyx
@@ -155,7 +155,10 @@ cdef class SpectralPowerPipeline0D(Pipeline0D):
 
             self._render_display()
             # workaround for interactivity for QT backend
-            plt.pause(0.1)
+            try:
+                plt.pause(0.1)
+            except NotImplementedError:
+                pass
 
     @cython.boundscheck(False)
     @cython.wraparound(False)


### PR DESCRIPTION
When using the `%matplotlib notebook` magic in Jupyter (iPython)
notebooks, the `pause()` function is not implemented. This causes
Matplotlib to raise an error when observations are made using
certain pipelines (RGB, bayer, spectral and mono pipelines).

However, the `pause()` function is only called to work around a lack
of live updating in the Matplotlib QT backend. This workaround is
not needed in the notebook backend, so can be skipped.

The attached (zipped) notebook demonstrates correct functioning of a couple of the demos in a Jupyter notebook. I have also tested the demos at the command line with the QT5 backend, and they still run fine.
[notebook_test.zip](https://github.com/raysect/source/files/2438560/notebook_test.zip)
