### PR TITLE
Logging ray should store the ray intersection objects (#250)

### DIFF
--- a/raysect/optical/loggingray.pyx
+++ b/raysect/optical/loggingray.pyx
@@ -188,3 +188,13 @@ cdef class LoggingRay(Ray):
                           self.max_distance, self._extinction_prob, self._extinction_min_depth,
                           self._max_depth, self.importance_sampling, self._important_path_weight)
 
+    @property
+    def path_vertices(self):
+
+        if self.log:
+            vertices = [self.origin.copy()]
+            vertices += [intersection.hit_point.transform(intersection.primitive_to_world) for intersection in self.log]
+            return vertices
+        else:
+            return []
+

--- a/raysect/optical/loggingray.pyx
+++ b/raysect/optical/loggingray.pyx
@@ -191,10 +191,13 @@ cdef class LoggingRay(Ray):
     @property
     def path_vertices(self):
 
+        cdef:
+            list vertices
+            Intersection intersection
+
         if self.log:
             vertices = [self.origin.copy()]
             vertices += [intersection.hit_point.transform(intersection.primitive_to_world) for intersection in self.log]
             return vertices
         else:
             return []
-

--- a/raysect/optical/loggingray.pyx
+++ b/raysect/optical/loggingray.pyx
@@ -105,7 +105,7 @@ cdef class LoggingRay(Ray):
 
             # this is the primary ray, count starts at 1 as the primary ray is the first ray
             self.ray_count = 1
-            self.log = [self.origin]
+            self.log = [(self.origin, None)]
 
         # create a new spectrum object compatible with the ray
         spectrum = self.new_spectrum()
@@ -123,7 +123,7 @@ cdef class LoggingRay(Ray):
         # does the ray intersect with any of the primitives in the world?
         intersection = world.hit(self)
         if intersection is not None:
-            self.log.append(intersection.hit_point.transform(intersection.primitive_to_world))
+            self.log.append((intersection.hit_point.transform(intersection.primitive_to_world), intersection))
             spectrum = self._sample_surface(intersection, world)
             spectrum = self._sample_volumes(spectrum, intersection, world)
 

--- a/raysect/optical/loggingray.pyx
+++ b/raysect/optical/loggingray.pyx
@@ -105,7 +105,7 @@ cdef class LoggingRay(Ray):
 
             # this is the primary ray, count starts at 1 as the primary ray is the first ray
             self.ray_count = 1
-            self.log = [(self.origin, None)]
+            self.log = []
 
         # create a new spectrum object compatible with the ray
         spectrum = self.new_spectrum()
@@ -123,7 +123,7 @@ cdef class LoggingRay(Ray):
         # does the ray intersect with any of the primitives in the world?
         intersection = world.hit(self)
         if intersection is not None:
-            self.log.append((intersection.hit_point.transform(intersection.primitive_to_world), intersection))
+            self.log.append(intersection)
             spectrum = self._sample_surface(intersection, world)
             spectrum = self._sample_volumes(spectrum, intersection, world)
 


### PR DESCRIPTION
As per issue #250, the logging ray should store the ray intersection objects. I've now changed this behavior, however there is now intersection object for the ray origin point. This must be extracted manually from the ray's origin attribute.