### PR TITLE
Add functions for max, min and peak-to-peak values of memoryviews

### DIFF
--- a/raysect/core/math/cython/utility.pyx
+++ b/raysect/core/math/cython/utility.pyx
@@ -435,3 +435,78 @@ def _point_inside_polygon(vertices, ptx, pty):
     return point_inside_polygon(vertices, ptx, pty)
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef double max_(double[:] data) nogil:
+    """Return the maximum value in the buffer data
+
+    This is equivalent to Python's max() function, but is far faster
+    for objects supporting the buffer interface where each element is a
+    double.
+
+    :param double data: Memoryview of an array of 1D data
+    :rtype: double
+    """
+    cdef:
+        int i
+        double result
+    result = data[0]
+    for i in range(1, data.shape[0]):
+        result = max(result, data[i])
+    return result
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef double min_(double[:] data) nogil:
+    """Return the minimum value in the buffer data
+
+    This is equivalent to Python's min() function, but is far faster
+    for objects supporting the buffer interface where each element is a
+    double.
+
+    :param double data: Memoryview of an array of 1D data
+    :rtype: double
+    """
+    cdef:
+        int i
+        double result
+    result = data[0]
+    for i in range(1, data.shape[0]):
+        result = min(result, data[i])
+    return result
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef double ptp_(double[:] data) nogil:
+    """Return the peak-to-peak value in the buffer data
+
+    This is equivalent to Python's max() - min(), but is far faster
+    for objects supporting the buffer interface where each element is a
+    double.
+
+    :param double data: Memoryview of an array of 1D data
+    :rtype: double
+    """
+    cdef:
+        int i
+        double result, max_, min_
+    max_ = data[0]
+    min_ = data[0]
+    for i in range(1, data.shape[0]):
+        max_ = max(max_, data[i])
+        min_ = min(min_, data[i])
+    result = max_ - min_
+    return result
+
+
+# Expose the limits functions to Python for testing
+def _min(data):
+    return min_(data)
+
+def _max(data):
+    return max_(data)
+
+def _ptp(data):
+    return ptp_(data)

--- a/raysect/core/math/tests/test_utility.py
+++ b/raysect/core/math/tests/test_utility.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,48 +27,20 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from numpy cimport ndarray
-cimport cython
+import unittest
+import numpy as np
+from raysect.core.math.cython.utility import _max, _min, _ptp
 
-cdef int find_index(double[::1] x, double v) nogil
+class TestLimits(unittest.TestCase):
 
-cdef double interpolate(double[::1] x, double[::1] y, double p) nogil
+    def test_max(self):
+        data = np.array([2, 4, -3, 9], dtype=float)
+        self.assertEqual(_max(data), 9)
 
-cdef double integrate(double[::1] x, double[::1] y, double x0, double x1) nogil
+    def test_min(self):
+        data = np.array([2, 4, -3, 9], dtype=float)
+        self.assertEqual(_min(data), -3)
 
-cdef double average(double[::1] x, double[::1] y, double x0, double x1) nogil
-
-cdef inline double clamp(double v, double minimum, double maximum) nogil:
-    if v < minimum:
-        return minimum
-    if v > maximum:
-        return maximum
-    return v
-
-cdef inline void swap_double(double *a, double *b) nogil:
-    cdef double temp
-    temp = a[0]
-    a[0] = b[0]
-    b[0] = temp
-
-cdef inline void swap_int(int *a, int *b) nogil:
-    cdef int temp
-    temp = a[0]
-    a[0] = b[0]
-    b[0] = temp
-
-@cython.cdivision(True)
-cdef inline double lerp(double x0, double x1, double y0, double y1, double x) nogil:
-    return ((y1 - y0) / (x1 - x0)) * (x - x0) + y0
-
-cdef bint solve_quadratic(double a, double b, double c, double *t0, double *t1) nogil
-
-cdef bint winding2d(double[:,::1] vertices) nogil
-
-cdef bint point_inside_polygon(double[:,::1] vertices, double ptx, double pty)
-
-cdef double max_(double[:] data) nogil
-
-cdef double min_(double[:] data) nogil
-
-cdef double ptp_(double[:] data) nogil
+    def test_ptp(self):
+        data = np.array([2, 4, -3, 9], dtype=float)
+        self.assertEqual(_ptp(data), 12)


### PR DESCRIPTION
The Python built-in `min()` and `max()` functions are very slow on memoryviews, and Numpy's `min` and `max` are also slow when called many times on small memoryviews. I found this to be a significant bottleneck in Cherab when creating arrays of many voxels where each voxel contains small arrays of vertex coordinates. I couldn't find any built-in function to quickly calculate these values without going into Python space, so I added some myself.

I could have put these somewhere in cherab-core, but they seem sufficiently general that they could live with the other miscellaneous Cython functions in Raysect. What do you think? Is this the right place for them?

Also, I went with restricting the functions to working on arrays of double only, and named them similar to the builtins but with a trailing underscore to distinguish them. I know `ptp` isn't a builtin but I kept the underscore for consistency. Do you think these are suitable decisions?