### PR TITLE
Implement __pow__ operator for FunctionxD objects

### DIFF
--- a/raysect/core/math/function/function1d/base.pxd
+++ b/raysect/core/math/function/function1d/base.pxd
@@ -56,6 +56,14 @@ cdef class DivideFunction1D(Function1D):
     cdef Function1D _function1, _function2
 
 
+cdef class PowFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class ModuloFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
 cdef class AddScalar1D(Function1D):
     cdef double _value
     cdef Function1D _function
@@ -72,5 +80,25 @@ cdef class MultiplyScalar1D(Function1D):
 
 
 cdef class DivideScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class ModuloScalarFunction1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class ModuloFunctionScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class PowScalarFunction1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class PowFunctionScalar1D(Function1D):
     cdef double _value
     cdef Function1D _function

--- a/raysect/core/math/function/function1d/tests/test_base.py
+++ b/raysect/core/math/function/function1d/tests/test_base.py
@@ -31,6 +31,7 @@
 Unit tests for the Function1D class.
 """
 
+import math
 import unittest
 from raysect.core.math.function.function1d.base import PythonFunction1D
 
@@ -95,6 +96,42 @@ class TestFunction1D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0)
 
+    def test_mod_function1d_scalar(self):
+        # Note that Function1D objects work with doubles, so the floating modulo
+        # operator is used rather than the integer one. For accurate testing we
+        # therefore need to use the math.fmod operator rather than % in Python.
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 % self.f1
+        r2 = self.f1 % -7.8
+        for x in v:
+            self.assertAlmostEqual(r1(x), math.fmod(5, self.f1_ref(x)), 15, "Function1D modulo scalar (K % f()) did not match reference function value.")
+            self.assertAlmostEqual(r2(x), math.fmod(self.f1_ref(x), -7.8), 15, "Function1D modulo scalar (f() % K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0"):
+            r1(0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when modulo scalar is 0"):
+            self.f1 % 0
+
+    def test_pow_function1d_scalar(self):
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 ** self.f1
+        r2 = self.f1 ** -7.8
+        r3 = (-5) ** self.f1
+        for x in v:
+            self.assertAlmostEqual(r1(x), 5 ** self.f1_ref(x), 15, "Function1D power scalar (K ** f()) did not match reference function value.")
+            if self.f1_ref(x) < 0:
+                with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                    r2(x)
+            elif not float(self.f1_ref(x)).is_integer():
+                with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                    r3(x)
+            else:
+                self.assertAlmostEqual(r2(x), self.f1_ref(x) ** -7.8, 15, "Function1D power scalar (f() ** K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+            r2(0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+            r4 = 0 ** self.f1
+            r4(-1)
+
     def test_add_function1d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 + self.f2
@@ -122,3 +159,36 @@ class TestFunction1D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0)
 
+    def test_mod_function1d(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e9]
+        r = self.f1 % self.f2
+        for x in v:
+            self.assertAlmostEqual(r(x), math.fmod(self.f1_ref(x), self.f2_ref(x)), delta=abs(r(x)) * 1e-12, msg="Function1D modulo function (f1() % f2()) did not match reference function value.")
+
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
+            r(0)
+
+    def test_pow_function1d_function1d(self):
+        v = [-1e1, -7, -0.001, 0.00003, 2]
+        r = self.f1 ** self.f2
+        for x in v:
+            if self.f1_ref(x) < 0 and not float(self.f2_ref(x)).is_integer():
+                with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                    r(x)
+            else:
+                self.assertAlmostEqual(r(x), self.f1_ref(x) ** self.f2_ref(x), 15, "Function1D power function (f1() ** f2()) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when f1() == 0 and f2() is negative"):
+            r = PythonFunction1D(lambda x: 0) ** self.f1
+            r(-1)
+
+    def test_pow_3_arguments(self):
+        v = [-1e1, -7, -0.001, 0.00003, 2]
+        r1 = pow(self.f1, 5, 3)
+        r2 = pow(5, self.f1, 3)
+        r3 = pow(5, self.f1, self.f2)
+        # Can't use 3 argument pow() if all arguments aren't integers, so
+        # use fmod(a, b) % c instead
+        for x in v:
+            self.assertEqual(r1(x), math.fmod(self.f1_ref(x) ** 5, 3), "Function1D 3 argument pow(f1(), A, B) did not match reference value")
+            self.assertEqual(r2(x), math.fmod(5 ** self.f1_ref(x), 3), "Function1D 3 argument pow(A, f1(), B) did not match reference value")
+            self.assertEqual(r3(x), math.fmod(5 ** self.f1_ref(x), self.f2_ref(x)), "Function1D 3 argument pow(A, f1(), f2()) did not match reference value")

--- a/raysect/core/math/function/function2d/base.pxd
+++ b/raysect/core/math/function/function2d/base.pxd
@@ -58,6 +58,14 @@ cdef class DivideFunction2D(Function2D):
     cdef Function2D _function1, _function2
 
 
+cdef class ModuloFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class PowFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
 cdef class AddScalar2D(Function2D):
     cdef double _value
     cdef Function2D _function
@@ -74,5 +82,25 @@ cdef class MultiplyScalar2D(Function2D):
 
 
 cdef class DivideScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class ModuloScalarFunction2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class ModuloFunctionScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class PowScalarFunction2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class PowFunctionScalar2D(Function2D):
     cdef double _value
     cdef Function2D _function

--- a/raysect/core/math/function/function2d/tests/test_base.py
+++ b/raysect/core/math/function/function2d/tests/test_base.py
@@ -31,6 +31,7 @@
 Unit tests for the Function2D class.
 """
 
+import math
 import unittest
 from raysect.core.math.function.function2d.base import PythonFunction2D
 
@@ -101,28 +102,66 @@ class TestFunction2D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0, 0)
 
-    def test_add_function1d(self):
+    def test_mod_function2d_scalar(self):
+        # Note that Function2D objects work with doubles, so the floating modulo
+        # operator is used rather than the integer one. For accurate testing we
+        # therefore need to use the math.fmod operator rather than % in Python.
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 % self.f1
+        r2 = self.f1 % -7.8
+        for x in v:
+            for y in v:
+                self.assertAlmostEqual(r1(x, y), math.fmod(5, self.f1_ref(x, y)), 15, "Function2D modulo scalar (K % f()) did not match reference function value.")
+                self.assertAlmostEqual(r2(x, y), math.fmod(self.f1_ref(x, y), -7.8), 15, "Function2D modulo scalar (f() % K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0"):
+            r1(0, 0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when modulo scalar is 0"):
+            self.f1 % 0
+
+    def test_pow_function2d_scalar(self):
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 ** self.f1
+        r2 = self.f1 ** -7.8
+        r3 = (-5) ** self.f1
+        for x in v:
+            for y in v:
+                self.assertAlmostEqual(r1(x, y), 5 ** self.f1_ref(x, y), 15, "Function2D power scalar (K ** f()) did not match reference function value.")
+                if self.f1_ref(x, y) < 0:
+                    with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                        r2(x, y)
+                elif not float(self.f1_ref(x, y)).is_integer():
+                    with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                        r3(x, y)
+                else:
+                    self.assertAlmostEqual(r2(x, y), self.f1_ref(x, y) ** -7.8, 15, "Function2D power scalar (f() ** K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+            r2(0, 0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+            r4 = 0 ** self.f1
+            r4(-1, 0)
+
+    def test_add_function2d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 + self.f2
         for x in v:
             for y in v:
                 self.assertEqual(r(x, y), self.f1_ref(x, y) + self.f2_ref(x, y), "Function2D add function (f1() + f2()) did not match reference function value.")
 
-    def test_sub_function1d(self):
+    def test_sub_function2d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 - self.f2
         for x in v:
             for y in v:
                 self.assertEqual(r(x, y), self.f1_ref(x, y) - self.f2_ref(x, y), "Function2D subtract function (f1() - f2()) did not match reference function value.")
 
-    def test_mul_function1d(self):
+    def test_mul_function2d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 * self.f2
         for x in v:
             for y in v:
                 self.assertEqual(r(x, y), self.f1_ref(x, y) * self.f2_ref(x, y), "Function2D multiply function (f1() * f2()) did not match reference function value.")
 
-    def test_div_function1d(self):
+    def test_div_function2d(self):
         v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
         r = self.f1 / self.f2
         for x in v:
@@ -132,3 +171,39 @@ class TestFunction2D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0, 0)
 
+    def test_mod_function2d(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e9]
+        r = self.f1 % self.f2
+        for x in v:
+            for y in v:
+                self.assertAlmostEqual(r(x, y), math.fmod(self.f1_ref(x, y), self.f2_ref(x, y)), delta=abs(r(x, y)) * 1e-12, msg="Function2D modulo function (f1() % f2()) did not match reference function value.")
+
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
+            r(0, 0)
+
+    def test_pow_function2d_function2d(self):
+        v = [-3.0, -0.7, -0.001, 0.00003, 2]
+        r = self.f1 ** self.f2
+        for x in v:
+            for y in v:
+                if self.f1_ref(x, y) < 0 and not float(self.f2_ref(x, y)).is_integer():
+                    with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                        r(x, y)
+                else:
+                    self.assertAlmostEqual(r(x, y), self.f1_ref(x, y) ** self.f2_ref(x, y), 15, "Function2D power function (f1() ** f2()) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when f1() == 0 and f2() is negative"):
+            r = PythonFunction2D(lambda x, y: 0) ** self.f1
+            r(-1, 0)
+
+    def test_pow_3_arguments(self):
+        v = [-1e1, -7, -0.001, 0.00003, 2]
+        r1 = pow(self.f1, 5, 3)
+        r2 = pow(5, self.f1, 3)
+        r3 = pow(5, self.f1, self.f2)
+        # Can't use 3 argument pow() if all arguments aren't integers, so
+        # use fmod(a, b) % c instead
+        for x in v:
+            for y in v:
+                self.assertEqual(r1(x, y), math.fmod(self.f1_ref(x, y) ** 5, 3), "Function2D 3 argument pow(f1(), A, B) did not match reference value")
+                self.assertEqual(r2(x, y), math.fmod(5 ** self.f1_ref(x, y), 3), "Function2D 3 argument pow(A, f1(), B) did not match reference value")
+                self.assertEqual(r3(x, y), math.fmod(5 ** self.f1_ref(x, y), self.f2_ref(x, y)), "Function2D 3 argument pow(A, f1(), f2()) did not match reference value")

--- a/raysect/core/math/function/function3d/base.pxd
+++ b/raysect/core/math/function/function3d/base.pxd
@@ -58,6 +58,14 @@ cdef class DivideFunction3D(Function3D):
     cdef Function3D _function1, _function2
 
 
+cdef class ModuloFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class PowFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
 cdef class AddScalar3D(Function3D):
     cdef double _value
     cdef Function3D _function
@@ -74,5 +82,25 @@ cdef class MultiplyScalar3D(Function3D):
 
 
 cdef class DivideScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class ModuloScalarFunction3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class ModuloFunctionScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class PowScalarFunction3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class PowFunctionScalar3D(Function3D):
     cdef double _value
     cdef Function3D _function

--- a/raysect/core/math/function/function3d/tests/test_base.py
+++ b/raysect/core/math/function/function3d/tests/test_base.py
@@ -31,6 +31,7 @@
 Unit tests for the Function3D class.
 """
 
+import math
 import unittest
 from raysect.core.math.function.function3d.base import PythonFunction3D
 
@@ -107,7 +108,55 @@ class TestFunction3D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0, 0, 0)
 
-    def test_add_function1d(self):
+    def test_mod_function3d_scalar(self):
+        # Note that Function3D objects work with doubles, so the floating modulo
+        # operator is used rather than the integer one. For accurate testing we
+        # therefore need to use the math.fmod operator rather than % in Python.
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 % self.f1
+        r2 = self.f1 % -7.8
+        for x in v:
+            for y in v:
+                for z in v:
+                    if self.f1_ref(x, y, z) == 0:
+                        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0"):
+                            r1(x, y, z)
+                    else:
+                        self.assertAlmostEqual(r1(x, y, z), math.fmod(5, self.f1_ref(x, y, z)), 15, "Function3D modulo scalar (K % f()) did not match reference function value.")
+                    self.assertAlmostEqual(r2(x, y, z), math.fmod(self.f1_ref(x, y, z), -7.8), 15, "Function3D modulo scalar (f() % K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0"):
+            r1(0, 0, 0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when modulo scalar is 0"):
+            self.f1 % 0
+
+    def test_pow_function3d_scalar(self):
+        v = [-1e1, -7, -0.001, 0.00003, 10, 12.3]
+        r1 = 5 ** self.f1
+        r2 = self.f1 ** -7.8
+        r3 = (-5) ** self.f1
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertAlmostEqual(r1(x, y, z), 5 ** self.f1_ref(x, y, z), 15, "Function3D power scalar (K ** f()) did not match reference function value.")
+                    if self.f1_ref(x, y, z) < 0:
+                        with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                            r2(x, y, z)
+                    elif not float(self.f1_ref(x, y, z)).is_integer():
+                        with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                            r3(x, y, z)
+                    else:
+                        if self.f1_ref(x, y, z) == 0:
+                            with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+                                r2(x, y, z)
+                        else:
+                            self.assertAlmostEqual(r2(x, y, z), self.f1_ref(x, y, z) ** -7.8, 15, "Function3D power scalar (f() ** K) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative"):
+            r2(0, 0, 0)
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is zero and exponent negative"):
+            r4 = 0 ** self.f1
+            r4(-1, 0, 0)
+
+    def test_add_function3d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 + self.f2
         for x in v:
@@ -115,7 +164,7 @@ class TestFunction3D(unittest.TestCase):
                 for z in v:
                     self.assertEqual(r(x, y, z), self.f1_ref(x, y, z) + self.f2_ref(x, y, z), "Function3D add function (f1() + f2()) did not match reference function value.")
 
-    def test_sub_function1d(self):
+    def test_sub_function3d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 - self.f2
         for x in v:
@@ -123,7 +172,7 @@ class TestFunction3D(unittest.TestCase):
                 for z in v:
                     self.assertEqual(r(x, y, z), self.f1_ref(x, y, z) - self.f2_ref(x, y, z), "Function3D subtract function (f1() - f2()) did not match reference function value.")
 
-    def test_mul_function1d(self):
+    def test_mul_function3d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = self.f1 * self.f2
         for x in v:
@@ -131,7 +180,7 @@ class TestFunction3D(unittest.TestCase):
                 for z in v:
                     self.assertEqual(r(x, y, z), self.f1_ref(x, y, z) * self.f2_ref(x, y, z), "Function3D multiply function (f1() * f2()) did not match reference function value.")
 
-    def test_div_function1d(self):
+    def test_div_function3d(self):
         v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
         r = self.f1 / self.f2
         for x in v:
@@ -142,3 +191,42 @@ class TestFunction3D(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r(0, 0, 0)
 
+    def test_mod_function3d(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
+        r = self.f1 % self.f2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertAlmostEqual(r(x, y, z), math.fmod(self.f1_ref(x, y, z), self.f2_ref(x, y, z)), delta=abs(r(x, y, z)) * 1e-12, msg="Function3D modulo function (f1() % f2()) did not match reference function value.")
+
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
+            r(0, 0, 0)
+
+    def test_pow_function3d_function3d(self):
+        v = [-3.0, -0.7, -0.001, 0.00003, 2]
+        r = self.f1 ** self.f2
+        for x in v:
+            for y in v:
+                for z in v:
+                    if self.f1_ref(x, y, z) < 0 and not float(self.f2_ref(x, y, z)).is_integer():
+                        with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral"):
+                            r(x, y, z)
+                    else:
+                        self.assertAlmostEqual(r(x, y, z), self.f1_ref(x, y, z) ** self.f2_ref(x, y, z), 15, "Function3D power function (f1() ** f2()) did not match reference function value.")
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when f1() == 0 and f2() is negative"):
+            r = PythonFunction3D(lambda x, y, z: 0) ** self.f1
+            r(-1, 0, 0)
+
+    def test_pow_3_arguments(self):
+        v = [-1e1, -7, -0.001, 0.00003, 2]
+        r1 = pow(self.f1, 5, 3)
+        r2 = pow(5, self.f1, 3)
+        r3 = pow(5, self.f1, self.f2)
+        # Can't use 3 argument pow() if all arguments aren't integers, so
+        # use fmod(a, b) % c instead
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), math.fmod(self.f1_ref(x, y, z) ** 5, 3), "Function3D 3 argument pow(f1(), A, B) did not match reference value")
+                    self.assertEqual(r2(x, y, z), math.fmod(5 ** self.f1_ref(x, y, z), 3), "Function3D 3 argument pow(A, f1(), B) did not match reference value")
+                    self.assertEqual(r3(x, y, z), math.fmod(5 ** self.f1_ref(x, y, z), self.f2_ref(x, y, z)), "Function3D 3 argument pow(A, f1(), f2()) did not match reference value")


### PR DESCRIPTION
Supports using FunctionxD objects in expressions such as f1 ** f2,
f1 ** const and const ** f1.

To fully support the 3 argument form of __pow__, __mod__ is also
implemented. This behaves in the same way as math.fmod in Python, and
the C function fmod.

Fixes #308 