### PR TITLE
Add ArgxD function objects

### DIFF
--- a/docs/source/api_reference/core/functions.rst
+++ b/docs/source/api_reference/core/functions.rst
@@ -12,6 +12,9 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function1d.constant.Constant1D
    :show-inheritance:
 
+.. autoclass:: raysect.core.math.function.function1d.arg.Arg1D
+   :show-inheritance:
+
 .. autoclass:: raysect.core.math.function.function2d.base.Function2D
    :members:
    :special-members: __call__
@@ -20,6 +23,9 @@ Functions and Interpolators
    :show-inheritance:
 
 .. autoclass:: raysect.core.math.function.function2d.constant.Constant2D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function2d.arg.Arg2D
    :show-inheritance:
 
 .. autoclass:: raysect.core.math.function.function3d.base.Function3D
@@ -32,10 +38,13 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function3d.constant.Constant3D
    :show-inheritance:
 
-.. automodule:: raysect.core.math.interpolators.discrete2dmesh
+.. autoclass:: raysect.core.math.function.function3d.arg.Arg3D
+   :show-inheritance:
+
+.. automodule:: raysect.core.math.function.function2d.interpolate.discrete2dmesh
    :show-inheritance:
    :members:
 
-.. automodule:: raysect.core.math.interpolators.interpolator2dmesh
+.. automodule:: raysect.core.math.function.function2d.interpolate.interpolator2dmesh
    :show-inheritance:
    :members:

--- a/raysect/core/math/function/function1d/__init__.pxd
+++ b/raysect/core/math/function/function1d/__init__.pxd
@@ -32,3 +32,4 @@
 from raysect.core.math.function.function1d.base cimport Function1D
 from raysect.core.math.function.function1d.constant cimport Constant1D
 from raysect.core.math.function.function1d.autowrap cimport autowrap_function1d
+from raysect.core.math.function.function1d.arg cimport Arg1D

--- a/raysect/core/math/function/function1d/__init__.py
+++ b/raysect/core/math/function/function1d/__init__.py
@@ -31,3 +31,4 @@
 
 from .base import Function1D
 from .constant import Constant1D
+from .arg import Arg1D

--- a/raysect/core/math/function/function1d/arg.pxd
+++ b/raysect/core/math/function/function1d/arg.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+from raysect.core.math.function.function1d.base cimport Function1D
+
+
+cdef class Arg1D(Function1D):
+    pass

--- a/raysect/core/math/function/function1d/arg.pyx
+++ b/raysect/core/math/function/function1d/arg.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,26 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+from raysect.core.math.function.function1d.base cimport Function1D
+
+
+cdef class Arg1D(Function1D):
+    """
+    Returns the argument the function is passed, unmodified
+
+    This is used to pass coordinates through to other functions in the
+    function framework which expect a Function1D object.
+
+    >>> arg = Arg1D()
+    >>> arg(2)
+    2.0
+    >>> arg(-3.14)
+    -3.14
+    >>> squarer = Arg1D()**2
+    >>> squarer(2)
+    4.0
+    >>> squarer(-3.14)
+    9.8596
+    """
+    cdef double evaluate(self, double x) except? -1e999:
+        return x

--- a/raysect/core/math/function/function1d/tests/__init__.py
+++ b/raysect/core/math/function/function1d/tests/__init__.py
@@ -1,3 +1,4 @@
 from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
+from .test_arg import *

--- a/raysect/core/math/function/function1d/tests/test_arg.py
+++ b/raysect/core/math/function/function1d/tests/test_arg.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,7 +27,18 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+"""
+Unit tests for the Arg1D class.
+"""
+
+import unittest
+from raysect.core.math.function.function1d.arg import Arg1D
+
+# TODO: expand tests to cover the cython interface
+class TestArg1D(unittest.TestCase):
+
+    def test_arg(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            arg = Arg1D()
+            self.assertEqual(arg(x), x, "Arg1D call did not match reference value")

--- a/raysect/core/math/function/function2d/__init__.pxd
+++ b/raysect/core/math/function/function2d/__init__.pxd
@@ -33,4 +33,4 @@ from raysect.core.math.function.function2d.base cimport Function2D
 from raysect.core.math.function.function2d.constant cimport Constant2D
 from raysect.core.math.function.function2d.autowrap cimport autowrap_function2d
 from raysect.core.math.function.function2d.interpolate cimport *
-
+from raysect.core.math.function.function2d.arg cimport Arg2D

--- a/raysect/core/math/function/function2d/__init__.py
+++ b/raysect/core/math/function/function2d/__init__.py
@@ -32,3 +32,4 @@
 from .base import Function2D
 from .constant import Constant2D
 from .interpolate import *
+from .arg import Arg2D

--- a/raysect/core/math/function/function2d/arg.pxd
+++ b/raysect/core/math/function/function2d/arg.pxd
@@ -29,7 +29,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+from raysect.core.math.function.function2d.base cimport Function2D
+
+cdef enum ArgLabel:
+    X, Y
+
+cdef class Arg2D(Function2D):
+    cdef ArgLabel _argument

--- a/raysect/core/math/function/function2d/arg.pyx
+++ b/raysect/core/math/function/function2d/arg.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,40 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+from raysect.core.math.function.function2d.base cimport Function2D
+
+
+cdef class Arg2D(Function2D):
+    """
+    Returns one of the arguments the function is passed, unmodified
+
+    This is used to pass coordinates through to other functions in the
+    function framework which expect a Function2D object.
+
+    Valid options for argument are "x" and "y".
+
+    >>> argx = Arg2D("x")
+    >>> argx(2, 3)
+    2.0
+    >>> argy = Arg2D("y")
+    >>> argy(2, 3)
+    3.0
+    >>> squarerx = argx**2
+    >>> squarerx(2, 3)
+    4.0
+    >>> squarery = argy**2
+    >>> squarery(2, 3)
+    9.0
+
+    :param str argument: either "x" or "y", the argument to return
+    """
+    def __init__(self, object argument):
+        if argument == "x":
+            self._argument = X
+        elif argument == "y":
+            self._argument = Y
+        else:
+            raise ValueError("The argument to Arg2D must be either 'x' or 'y'")
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return x if self._argument == X else y

--- a/raysect/core/math/function/function2d/tests/__init__.py
+++ b/raysect/core/math/function/function2d/tests/__init__.py
@@ -1,3 +1,4 @@
 from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
+from .test_arg import *

--- a/raysect/core/math/function/function2d/tests/test_arg.py
+++ b/raysect/core/math/function/function2d/tests/test_arg.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,7 +27,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+"""
+Unit tests for the Arg2D class.
+"""
+
+import unittest
+from raysect.core.math.function.function2d.arg import Arg2D
+
+# TODO: expand tests to cover the cython interface
+class TestArg2D(unittest.TestCase):
+
+    def test_arg(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                argx = Arg2D("x")
+                argy = Arg2D("y")
+                self.assertEqual(argx(x, y), x, "Arg2D('x') call did not match reference value")
+                self.assertEqual(argy(x, y), y, "Arg2D('y') call did not match reference value")
+
+    def test_invalid_inputs(self):
+        with self.assertRaises(ValueError, msg="Arg2D did not raise ValueError with incorrect string"):
+            Arg2D("z")

--- a/raysect/core/math/function/function3d/__init__.py
+++ b/raysect/core/math/function/function3d/__init__.py
@@ -31,3 +31,4 @@
 
 from .base import Function3D
 from .constant import Constant3D
+from .arg import Arg3D

--- a/raysect/core/math/function/function3d/arg.pxd
+++ b/raysect/core/math/function/function3d/arg.pxd
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+
+cdef enum ArgLabel:
+    X, Y, Z
+
+cdef class Arg3D(Function3D):
+    cdef ArgLabel _argument

--- a/raysect/core/math/function/function3d/arg.pyx
+++ b/raysect/core/math/function/function3d/arg.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,47 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+
+
+cdef class Arg3D(Function3D):
+    """
+    Returns one of the arguments the function is passed, unmodified
+
+    This is used to pass coordinates through to other functions in the
+    function framework which expect a Function3D object.
+
+    Valid options for argument are "x", "y" or "z".
+
+    >>> argx = Arg3D("x")
+    >>> argx(2, 3, 5)
+    2.0
+    >>> argy = Arg3D("y")
+    >>> argy(2, 3, 5)
+    3.0
+    >>> argz = Arg3D("z")
+    >>> argz(2, 3, 5)
+    5.0
+    >>> squarerx = argx**2
+    >>> squarerx(2, 3, 5)
+    4.0
+    >>> squarery = argy**2
+    >>> squarery(2, 3, 5)
+    9.0
+    >>> squarerz = argz**2
+    >>> squarerz(2, 3, 5)
+    25.0
+
+    :param str argument: either "x", "y" or "z", the argument to return
+    """
+    def __init__(self, object argument):
+        if argument == "x":
+            self._argument = X
+        elif argument == "y":
+            self._argument = Y
+        elif argument == "z":
+            self._argument = Z
+        else:
+            raise ValueError("The argument to Arg3D must be either 'x', 'y' or 'z'")
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return x if self._argument == X else y if self._argument == Y else z

--- a/raysect/core/math/function/function3d/tests/__init__.py
+++ b/raysect/core/math/function/function3d/tests/__init__.py
@@ -1,3 +1,4 @@
 from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
+from .test_arg import *

--- a/raysect/core/math/function/function3d/tests/test_arg.py
+++ b/raysect/core/math/function/function3d/tests/test_arg.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,7 +27,28 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.function3d.base cimport Function3D
-from raysect.core.math.function.function3d.constant cimport Constant3D
-from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
-from raysect.core.math.function.function3d.arg cimport Arg3D
+"""
+Unit tests for the Arg3D class.
+"""
+
+import unittest
+from raysect.core.math.function.function3d.arg import Arg3D
+
+# TODO: expand tests to cover the cython interface
+class TestArg3D(unittest.TestCase):
+
+    def test_arg(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    argx = Arg3D("x")
+                    argy = Arg3D("y")
+                    argz = Arg3D("z")
+                    self.assertEqual(argx(x, y, z), x, "Arg3D('x') call did not match reference value")
+                    self.assertEqual(argy(x, y, z), y, "Arg3D('y') call did not match reference value")
+                    self.assertEqual(argz(x, y, z), z, "Arg3D('z') call did not match reference value")
+
+    def test_invalid_inputs(self):
+        with self.assertRaises(ValueError, msg="Arg3D did not raise ValueError with incorrect string"):
+            Arg3D("w")


### PR DESCRIPTION
These return the argument with which they're called, and are intended
to be used in more complex expressions involving other FunctionxD
objects. For example, f(x, y) = e^(x + y) could be implemented as
Exp2D(Arg2D("x") + Arg2D("y")).

Fixes #311 

I've gone with Alex's [suggestion](https://github.com/raysect/source/issues/309#issuecomment-543115499) of `ArgxD` for the class names, rather than `IdentityxD`, but am happy to modify the name if anybody has any strong opinions.