### PR TITLE
Add ExpxD functions

### DIFF
--- a/docs/source/api_reference/core/functions.rst
+++ b/docs/source/api_reference/core/functions.rst
@@ -15,6 +15,9 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function1d.arg.Arg1D
    :show-inheritance:
 
+.. autoclass:: raysect.core.math.function.function1d.cmath.Exp1D
+   :show-inheritance:
+
 .. autoclass:: raysect.core.math.function.function2d.base.Function2D
    :members:
    :special-members: __call__
@@ -28,6 +31,9 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function2d.arg.Arg2D
    :show-inheritance:
 
+.. autoclass:: raysect.core.math.function.function2d.cmath.Exp2D
+   :show-inheritance:
+
 .. autoclass:: raysect.core.math.function.function3d.base.Function3D
    :members:
    :special-members: __call__
@@ -39,6 +45,9 @@ Functions and Interpolators
    :show-inheritance:
 
 .. autoclass:: raysect.core.math.function.function3d.arg.Arg3D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function3d.cmath.Exp3D
    :show-inheritance:
 
 .. automodule:: raysect.core.math.function.function2d.interpolate.discrete2dmesh

--- a/raysect/core/math/function/function1d/__init__.pxd
+++ b/raysect/core/math/function/function1d/__init__.pxd
@@ -33,3 +33,4 @@ from raysect.core.math.function.function1d.base cimport Function1D
 from raysect.core.math.function.function1d.constant cimport Constant1D
 from raysect.core.math.function.function1d.autowrap cimport autowrap_function1d
 from raysect.core.math.function.function1d.arg cimport Arg1D
+from raysect.core.math.function.function1d.cmath cimport *

--- a/raysect/core/math/function/function1d/__init__.py
+++ b/raysect/core/math/function/function1d/__init__.py
@@ -32,3 +32,4 @@
 from .base import Function1D
 from .constant import Constant1D
 from .arg import Arg1D
+from .cmath import *

--- a/raysect/core/math/function/function1d/cmath.pxd
+++ b/raysect/core/math/function/function1d/cmath.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+from raysect.core.math.function.function1d.base cimport Function1D
+
+
+cdef class Exp1D(Function1D):
+    cdef Function1D _function

--- a/raysect/core/math/function/function1d/cmath.pyx
+++ b/raysect/core/math/function/function1d/cmath.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,19 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+cimport libc.math as cmath
+from raysect.core.math.function.function1d.base cimport Function1D
+from raysect.core.math.function.function1d.autowrap cimport autowrap_function1d
+
+
+cdef class Exp1D(Function1D):
+    """
+    A Function1D class that implements the exponential of the result of a Function1D object: exp(f())
+
+    :param Function1D function: A Function1D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function1d(function)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        return cmath.exp(self._function.evaluate(x))

--- a/raysect/core/math/function/function1d/tests/__init__.py
+++ b/raysect/core/math/function/function1d/tests/__init__.py
@@ -2,3 +2,4 @@ from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
 from .test_arg import *
+from .test_cmath import *

--- a/raysect/core/math/function/function1d/tests/test_cmath.py
+++ b/raysect/core/math/function/function1d/tests/test_cmath.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,8 +27,24 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+"""
+Unit tests for the cmath wrapper classes.
+"""
+
+import math
+import unittest
+import raysect.core.math.function.function1d.cmath as cmath1d
+from raysect.core.math.function.function1d.autowrap import PythonFunction1D
+
+# TODO: expand tests to cover the cython interface
+class TestCmath1D(unittest.TestCase):
+
+    def setUp(self):
+        self.f1 = PythonFunction1D(lambda x: x / 10)
+
+    def test_exp(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            function = cmath1d.Exp1D(self.f1)
+            expected = math.exp(self.f1(x))
+            self.assertEqual(function(x), expected, "Exp1D call did not match reference value")

--- a/raysect/core/math/function/function2d/__init__.pxd
+++ b/raysect/core/math/function/function2d/__init__.pxd
@@ -34,3 +34,4 @@ from raysect.core.math.function.function2d.constant cimport Constant2D
 from raysect.core.math.function.function2d.autowrap cimport autowrap_function2d
 from raysect.core.math.function.function2d.interpolate cimport *
 from raysect.core.math.function.function2d.arg cimport Arg2D
+from raysect.core.math.function.function2d.cmath cimport *

--- a/raysect/core/math/function/function2d/cmath.pxd
+++ b/raysect/core/math/function/function2d/cmath.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+from raysect.core.math.function.function2d.base cimport Function2D
+
+
+cdef class Exp2D(Function2D):
+    cdef Function2D _function

--- a/raysect/core/math/function/function2d/cmath.pyx
+++ b/raysect/core/math/function/function2d/cmath.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,19 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+cimport libc.math as cmath
+from raysect.core.math.function.function2d.base cimport Function2D
+from raysect.core.math.function.function2d.autowrap cimport autowrap_function2d
+
+
+cdef class Exp2D(Function2D):
+    """
+    A Function2D class that implements the exponential of the result of a Function2D object: exp(f())
+
+    :param Function2D function: A Function2D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function2d(function)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return cmath.exp(self._function.evaluate(x, y))

--- a/raysect/core/math/function/function2d/tests/__init__.py
+++ b/raysect/core/math/function/function2d/tests/__init__.py
@@ -2,3 +2,4 @@ from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
 from .test_arg import *
+from .test_cmath import *

--- a/raysect/core/math/function/function2d/tests/test_cmath.py
+++ b/raysect/core/math/function/function2d/tests/test_cmath.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,8 +27,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+"""
+Unit tests for the cmath wrapper classes.
+"""
+
+import math
+import unittest
+import raysect.core.math.function.function2d.cmath as cmath2d
+from raysect.core.math.function.function2d.autowrap import PythonFunction2D
+
+# TODO: expand tests to cover the cython interface
+class TestCmath2D(unittest.TestCase):
+
+    def setUp(self):
+        self.f1 = PythonFunction2D(lambda x, y: x / 10 + y)
+
+    def test_exp(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                function = cmath2d.Exp2D(self.f1)
+                expected = math.exp(self.f1(x, y))
+                self.assertEqual(function(x, y), expected, "Exp2D call did not match reference value")

--- a/raysect/core/math/function/function3d/__init__.pxd
+++ b/raysect/core/math/function/function3d/__init__.pxd
@@ -33,3 +33,4 @@ from raysect.core.math.function.function3d.base cimport Function3D
 from raysect.core.math.function.function3d.constant cimport Constant3D
 from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
 from raysect.core.math.function.function3d.arg cimport Arg3D
+from raysect.core.math.function.function3d.cmath cimport *

--- a/raysect/core/math/function/function3d/__init__.py
+++ b/raysect/core/math/function/function3d/__init__.py
@@ -32,3 +32,4 @@
 from .base import Function3D
 from .constant import Constant3D
 from .arg import Arg3D
+from .cmath import *

--- a/raysect/core/math/function/function3d/cmath.pxd
+++ b/raysect/core/math/function/function3d/cmath.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+from raysect.core.math.function.function3d.base cimport Function3D
+
+
+cdef class Exp3D(Function3D):
+    cdef Function3D _function

--- a/raysect/core/math/function/function3d/cmath.pyx
+++ b/raysect/core/math/function/function3d/cmath.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,19 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+cimport libc.math as cmath
+from raysect.core.math.function.function3d.base cimport Function3D
+from raysect.core.math.function.function3d.autowrap cimport autowrap_function3d
+
+
+cdef class Exp3D(Function3D):
+    """
+    A Function3D class that implements the exponential of the result of a Function3D object: exp(f())
+
+    :param Function3D function: A Function3D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function3d(function)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return cmath.exp(self._function.evaluate(x, y, z))

--- a/raysect/core/math/function/function3d/tests/__init__.py
+++ b/raysect/core/math/function/function3d/tests/__init__.py
@@ -2,3 +2,4 @@ from .test_base import *
 from .test_autowrap import *
 from .test_constant import *
 from .test_arg import *
+from .test_cmath import *

--- a/raysect/core/math/function/function3d/tests/test_cmath.py
+++ b/raysect/core/math/function/function3d/tests/test_cmath.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2019, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,8 +27,26 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import Function2D
-from .constant import Constant2D
-from .interpolate import *
-from .arg import Arg2D
-from .cmath import *
+"""
+Unit tests for the cmath wrapper classes.
+"""
+
+import math
+import unittest
+import raysect.core.math.function.function3d.cmath as cmath3d
+from raysect.core.math.function.function3d.autowrap import PythonFunction3D
+
+# TODO: expand tests to cover the cython interface
+class TestCmath3D(unittest.TestCase):
+
+    def setUp(self):
+        self.f1 = PythonFunction3D(lambda x, y, z: x / 10 + y - z)
+
+    def test_exp(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                for z in v:
+                    function = cmath3d.Exp3D(self.f1)
+                    expected = math.exp(self.f1(x, y, z))
+                    self.assertEqual(function(x, y, z), expected, "Exp3D call did not match reference value")


### PR DESCRIPTION
These return exp(f()), where f() is a FunctionxD. This is the first of
a number of cmath wrappers for FunctionxD objects: the intention is to
add to the cmath.pyx files other functions from libc.math, hence the slightly different import syntax to usual (to avoid eventually having a really long `from libc.math cimport exp, sin, cos, ...` line).

Fixes #309 