### PR TITLE
Add sin, cos, atan and atan2 FunctionxD objects

### DIFF
--- a/docs/source/api_reference/core/functions.rst
+++ b/docs/source/api_reference/core/functions.rst
@@ -18,6 +18,18 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function1d.cmath.Exp1D
    :show-inheritance:
 
+.. autoclass:: raysect.core.math.function.function1d.cmath.Sin1D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function1d.cmath.Cos1D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function1d.cmath.Atan1D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function1d.cmath.Atan4Q1D
+   :show-inheritance:
+
 .. autoclass:: raysect.core.math.function.function2d.base.Function2D
    :members:
    :special-members: __call__
@@ -34,6 +46,18 @@ Functions and Interpolators
 .. autoclass:: raysect.core.math.function.function2d.cmath.Exp2D
    :show-inheritance:
 
+.. autoclass:: raysect.core.math.function.function2d.cmath.Sin2D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function2d.cmath.Cos2D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function2d.cmath.Atan2D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function2d.cmath.Atan4Q2D
+   :show-inheritance:
+
 .. autoclass:: raysect.core.math.function.function3d.base.Function3D
    :members:
    :special-members: __call__
@@ -48,6 +72,18 @@ Functions and Interpolators
    :show-inheritance:
 
 .. autoclass:: raysect.core.math.function.function3d.cmath.Exp3D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function3d.cmath.Sin3D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function3d.cmath.Cos3D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function3d.cmath.Atan3D
+   :show-inheritance:
+
+.. autoclass:: raysect.core.math.function.function3d.cmath.Atan4Q3D
    :show-inheritance:
 
 .. automodule:: raysect.core.math.function.function2d.interpolate.discrete2dmesh

--- a/raysect/core/math/function/function1d/cmath.pxd
+++ b/raysect/core/math/function/function1d/cmath.pxd
@@ -34,3 +34,19 @@ from raysect.core.math.function.function1d.base cimport Function1D
 
 cdef class Exp1D(Function1D):
     cdef Function1D _function
+
+
+cdef class Sin1D(Function1D):
+    cdef Function1D _function
+
+
+cdef class Cos1D(Function1D):
+    cdef Function1D _function
+
+
+cdef class Atan1D(Function1D):
+    cdef Function1D _function
+
+
+cdef class Atan4Q1D(Function1D):
+    cdef Function1D _numerator, _denominator

--- a/raysect/core/math/function/function1d/cmath.pyx
+++ b/raysect/core/math/function/function1d/cmath.pyx
@@ -45,3 +45,60 @@ cdef class Exp1D(Function1D):
 
     cdef double evaluate(self, double x) except? -1e999:
         return cmath.exp(self._function.evaluate(x))
+
+
+cdef class Sin1D(Function1D):
+    """
+    A Function1D class that implements the sine of the result of a Function1D object: sin(f())
+
+    :param Function1D function: A Function1D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function1d(function)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        return cmath.sin(self._function.evaluate(x))
+
+
+cdef class Cos1D(Function1D):
+    """
+    A Function1D class that implements the cosine of the result of a Function1D object: cos(f())
+
+    :param Function1D function: A Function1D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function1d(function)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        return cmath.cos(self._function.evaluate(x))
+
+
+cdef class Atan1D(Function1D):
+    """
+    A Function1D class that implements the arctangent of the result of a Function1D object: atan(f())
+
+    :param Function1D function: A Function1D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function1d(function)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        return cmath.atan(self._function.evaluate(x))
+
+
+cdef class Atan4Q1D(Function1D):
+    """
+    A Function1D class that implements the arctangent of the result of 2 Function1D objects: atan2(f1(), f2())
+
+    This differs from Atan1D in that it takes separate functions for the
+    numerator and denominator, in order to get the quadrant correct.
+
+    :param Function1D numerator: A Function1D object representing the numerator
+    :param Function1D denominator: A Function1D object representing the denominator
+    """
+    def __init__(self, object numerator, object denominator):
+        self._numerator = autowrap_function1d(numerator)
+        self._denominator = autowrap_function1d(denominator)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        return cmath.atan2(self._numerator.evaluate(x), self._denominator.evaluate(x))

--- a/raysect/core/math/function/function1d/tests/test_cmath.py
+++ b/raysect/core/math/function/function1d/tests/test_cmath.py
@@ -41,6 +41,7 @@ class TestCmath1D(unittest.TestCase):
 
     def setUp(self):
         self.f1 = PythonFunction1D(lambda x: x / 10)
+        self.f2 = PythonFunction1D(lambda x: x * x)
 
     def test_exp(self):
         v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
@@ -48,3 +49,31 @@ class TestCmath1D(unittest.TestCase):
             function = cmath1d.Exp1D(self.f1)
             expected = math.exp(self.f1(x))
             self.assertEqual(function(x), expected, "Exp1D call did not match reference value")
+
+    def test_sin(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            function = cmath1d.Sin1D(self.f1)
+            expected = math.sin(self.f1(x))
+            self.assertEqual(function(x), expected, "Sin1D call did not match reference value")
+
+    def test_cos(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            function = cmath1d.Cos1D(self.f1)
+            expected = math.cos(self.f1(x))
+            self.assertEqual(function(x), expected, "Cos1D call did not match reference value")
+
+    def test_atan(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            function = cmath1d.Atan1D(self.f1)
+            expected = math.atan(self.f1(x))
+            self.assertEqual(function(x), expected, "Atan1D call did not match reference value")
+
+    def test_atan2(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            function = cmath1d.Atan4Q1D(self.f1, self.f2)
+            expected = math.atan2(self.f1(x), self.f2(x))
+            self.assertEqual(function(x), expected, "Atan4Q1D call did not match reference value")

--- a/raysect/core/math/function/function2d/cmath.pxd
+++ b/raysect/core/math/function/function2d/cmath.pxd
@@ -34,3 +34,19 @@ from raysect.core.math.function.function2d.base cimport Function2D
 
 cdef class Exp2D(Function2D):
     cdef Function2D _function
+
+
+cdef class Sin2D(Function2D):
+    cdef Function2D _function
+
+
+cdef class Cos2D(Function2D):
+    cdef Function2D _function
+
+
+cdef class Atan2D(Function2D):
+    cdef Function2D _function
+
+
+cdef class Atan4Q2D(Function2D):
+    cdef Function2D _numerator, _denominator

--- a/raysect/core/math/function/function2d/cmath.pyx
+++ b/raysect/core/math/function/function2d/cmath.pyx
@@ -45,3 +45,60 @@ cdef class Exp2D(Function2D):
 
     cdef double evaluate(self, double x, double y) except? -1e999:
         return cmath.exp(self._function.evaluate(x, y))
+
+
+cdef class Sin2D(Function2D):
+    """
+    A Function2D class that implements the sine of the result of a Function2D object: sin(f())
+
+    :param Function2D function: A Function2D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function2d(function)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return cmath.sin(self._function.evaluate(x, y))
+
+
+cdef class Cos2D(Function2D):
+    """
+    A Function2D class that implements the cosine of the result of a Function2D object: cos(f())
+
+    :param Function2D function: A Function2D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function2d(function)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return cmath.cos(self._function.evaluate(x, y))
+
+
+cdef class Atan2D(Function2D):
+    """
+    A Function2D class that implements the arctangent of the result of a Function2D object: atan(f())
+
+    :param Function2D function: A Function2D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function2d(function)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return cmath.atan(self._function.evaluate(x, y))
+
+
+cdef class Atan4Q2D(Function2D):
+    """
+    A Function2D class that implements the arctangent of the result of 2 Function2D objects: atan2(f1(), f2())
+
+    This differs from Atan2D in that it takes separate functions for the
+    numerator and denominator, in order to get the quadrant correct.
+
+    :param Function2D numerator: A Function2D object representing the numerator
+    :param Function2D denominator: A Function2D object representing the denominator
+    """
+    def __init__(self, object numerator, object denominator):
+        self._numerator = autowrap_function2d(numerator)
+        self._denominator = autowrap_function2d(denominator)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return cmath.atan2(self._numerator.evaluate(x, y), self._denominator.evaluate(x, y))

--- a/raysect/core/math/function/function2d/tests/test_cmath.py
+++ b/raysect/core/math/function/function2d/tests/test_cmath.py
@@ -41,6 +41,7 @@ class TestCmath2D(unittest.TestCase):
 
     def setUp(self):
         self.f1 = PythonFunction2D(lambda x, y: x / 10 + y)
+        self.f2 = PythonFunction2D(lambda x, y: x * x + y * y)
 
     def test_exp(self):
         v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
@@ -49,3 +50,35 @@ class TestCmath2D(unittest.TestCase):
                 function = cmath2d.Exp2D(self.f1)
                 expected = math.exp(self.f1(x, y))
                 self.assertEqual(function(x, y), expected, "Exp2D call did not match reference value")
+
+    def test_sin(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                function = cmath2d.Sin2D(self.f1)
+                expected = math.sin(self.f1(x, y))
+                self.assertEqual(function(x, y), expected, "Sin2D call did not match reference value")
+
+    def test_cos(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                function = cmath2d.Cos2D(self.f1)
+                expected = math.cos(self.f1(x, y))
+                self.assertEqual(function(x, y), expected, "Cos2D call did not match reference value")
+
+    def test_atan(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                function = cmath2d.Atan2D(self.f1)
+                expected = math.atan(self.f1(x, y))
+                self.assertEqual(function(x, y), expected, "Atan2D call did not match reference value")
+
+    def test_atan2(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                function = cmath2d.Atan4Q2D(self.f1, self.f2)
+                expected = math.atan2(self.f1(x, y), self.f2(x, y))
+                self.assertEqual(function(x, y), expected, "Atan4Q2D call did not match reference value")

--- a/raysect/core/math/function/function3d/cmath.pxd
+++ b/raysect/core/math/function/function3d/cmath.pxd
@@ -34,3 +34,19 @@ from raysect.core.math.function.function3d.base cimport Function3D
 
 cdef class Exp3D(Function3D):
     cdef Function3D _function
+
+
+cdef class Sin3D(Function3D):
+    cdef Function3D _function
+
+
+cdef class Cos3D(Function3D):
+    cdef Function3D _function
+
+
+cdef class Atan3D(Function3D):
+    cdef Function3D _function
+
+
+cdef class Atan4Q3D(Function3D):
+    cdef Function3D _numerator, _denominator

--- a/raysect/core/math/function/function3d/cmath.pyx
+++ b/raysect/core/math/function/function3d/cmath.pyx
@@ -45,3 +45,60 @@ cdef class Exp3D(Function3D):
 
     cdef double evaluate(self, double x, double y, double z) except? -1e999:
         return cmath.exp(self._function.evaluate(x, y, z))
+
+
+cdef class Sin3D(Function3D):
+    """
+    A Function3D class that implements the sine of the result of a Function3D object: sin(f())
+
+    :param Function3D function: A Function3D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function3d(function)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return cmath.sin(self._function.evaluate(x, y, z))
+
+
+cdef class Cos3D(Function3D):
+    """
+    A Function3D class that implements the cosine of the result of a Function3D object: cos(f())
+
+    :param Function3D function: A Function3D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function3d(function)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return cmath.cos(self._function.evaluate(x, y, z))
+
+
+cdef class Atan3D(Function3D):
+    """
+    A Function3D class that implements the arctangent of the result of a Function3D object: atan(f())
+
+    :param Function3D function: A Function3D object.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function3d(function)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return cmath.atan(self._function.evaluate(x, y, z))
+
+
+cdef class Atan4Q3D(Function3D):
+    """
+    A Function3D class that implements the arctangent of the result of 2 Function3D objects: atan2(f1(), f2())
+
+    This differs from Atan3D in that it takes separate functions for the
+    numerator and denominator, in order to get the quadrant correct.
+
+    :param Function3D numerator: A Function3D object representing the numerator
+    :param Function3D denominator: A Function3D object representing the denominator
+    """
+    def __init__(self, object numerator, object denominator):
+        self._numerator = autowrap_function3d(numerator)
+        self._denominator = autowrap_function3d(denominator)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        return cmath.atan2(self._numerator.evaluate(x, y, z), self._denominator.evaluate(x, y, z))

--- a/raysect/core/math/function/function3d/tests/test_cmath.py
+++ b/raysect/core/math/function/function3d/tests/test_cmath.py
@@ -41,6 +41,7 @@ class TestCmath3D(unittest.TestCase):
 
     def setUp(self):
         self.f1 = PythonFunction3D(lambda x, y, z: x / 10 + y - z)
+        self.f2 = PythonFunction3D(lambda x, y, z: x * x + y * y - z * z)
 
     def test_exp(self):
         v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
@@ -50,3 +51,39 @@ class TestCmath3D(unittest.TestCase):
                     function = cmath3d.Exp3D(self.f1)
                     expected = math.exp(self.f1(x, y, z))
                     self.assertEqual(function(x, y, z), expected, "Exp3D call did not match reference value")
+
+    def test_sin(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                for z in v:
+                    function = cmath3d.Sin3D(self.f1)
+                    expected = math.sin(self.f1(x, y, z))
+                    self.assertEqual(function(x, y, z), expected, "Sin3D call did not match reference value")
+
+    def test_cos(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                for z in v:
+                    function = cmath3d.Cos3D(self.f1)
+                    expected = math.cos(self.f1(x, y, z))
+                    self.assertEqual(function(x, y, z), expected, "Cos3D call did not match reference value")
+
+    def test_atan(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                for z in v:
+                    function = cmath3d.Atan3D(self.f1)
+                    expected = math.atan(self.f1(x, y, z))
+                    self.assertEqual(function(x, y, z), expected, "Atan3D call did not match reference value")
+
+    def test_atan2(self):
+        v = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
+        for x in v:
+            for y in v:
+                for z in v:
+                    function = cmath3d.Atan4Q3D(self.f1, self.f2)
+                    expected = math.atan2(self.f1(x, y, z), self.f2(x, y, z))
+                    self.assertEqual(function(x, y, z), expected, "Atan4Q3D call did not match reference value")


### PR DESCRIPTION
Fixes #316. The awkward naming of `Atan2xD` is unfortunate, but I can't think of a better naming convention than copying the `libc.math` names and appending the dimension.