### PR TITLE
Add rich comparison operators to FunctionxD

### DIFF
--- a/raysect/core/math/function/function1d/base.pxd
+++ b/raysect/core/math/function/function1d/base.pxd
@@ -58,6 +58,34 @@ cdef class ModuloFunction1D(Function1D):
     cdef Function1D _function1, _function2
 
 
+cdef class AbsFunction1D(Function1D):
+    cdef Function1D _function
+
+
+cdef class EqualsFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class NotEqualsFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class LessThanFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class GreaterThanFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class LessEqualsFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class GreaterEqualsFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
 cdef class AddScalar1D(Function1D):
     cdef double _value
     cdef Function1D _function
@@ -98,11 +126,41 @@ cdef class PowFunctionScalar1D(Function1D):
     cdef Function1D _function
 
 
+cdef class EqualsScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class NotEqualsScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class LessThanScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class GreaterThanScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class LessEqualsScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
+cdef class GreaterEqualsScalar1D(Function1D):
+    cdef double _value
+    cdef Function1D _function
+
+
 cdef inline bint is_callable(object f):
     """
     Tests if an object is a python callable or function object.
-    
-    :param object f: Object to test.  
+
+    :param object f: Object to test.
     :return: True if callable, False otherwise.
     """
     return isinstance(f, Function1D) or callable(f)

--- a/raysect/core/math/function/function1d/tests/test_base.py
+++ b/raysect/core/math/function/function1d/tests/test_base.py
@@ -129,6 +129,125 @@ class TestFunction1D(unittest.TestCase):
             r4 = 0 ** self.f1
             r4(-1)
 
+    def test_richcmp_scalar(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.ref1(x)
+            higher_value = ref_value + abs(ref_value) + 1
+            lower_value = ref_value - abs(ref_value) - 1
+            self.assertEqual(
+                (self.f1 == ref_value)(x), 1.0,
+                msg="Function1D equals scalar (f() == K) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value == self.f1)(x), 1.0,
+                msg="Scalar equals Function1D (K == f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 == higher_value)(x), 0.0,
+                msg="Function1D equals scalar (f() == K) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value == self.f1)(x), 0.0,
+                msg="Scalar equals Function1D (K == f()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 != higher_value)(x), 1.0,
+                msg="Function1D not equals scalar (f() != K) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value != self.f1)(x), 1.0,
+                msg="Scalar not equals Function1D (K != f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 != ref_value)(x), 0.0,
+                msg="Function1D not equals scalar (f() != K) did not return false when it should."
+            )
+            self.assertEqual(
+                (ref_value != self.f1)(x), 0.0,
+                msg="Scalar not equals Function1D (K != f()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 < higher_value)(x), 1.0,
+                msg="Function1D less than scalar (f() < K) did not return true when it should."
+            )
+            self.assertEqual(
+                (lower_value < self.f1)(x), 1.0,
+                msg="Scalar less than Function1D (K < f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 < lower_value)(x), 0.0,
+                msg="Function1D less than scalar (f() < K) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value < self.f1)(x), 0.0,
+                msg="Scalar less than Function1D (K < f()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 > lower_value)(x), 1.0,
+                msg="Function1D greater than scalar (f() > K) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value > self.f1)(x), 1.0,
+                msg="Scalar greater than Function1D (K > f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 > higher_value)(x), 0.0,
+                msg="Function1D greater than scalar (f() > K) did not return false when it should."
+            )
+            self.assertEqual(
+                (lower_value > self.f1)(x), 0.0,
+                msg="Scalar greater than Function1D (K > f()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= higher_value)(x), 1.0,
+                msg="Function1D less equals scalar (f() <= K) did not return true when it should."
+            )
+            self.assertEqual(
+                (lower_value <= self.f1)(x), 1.0,
+                msg="Scalar less equals Function1D (K <= f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= ref_value)(x), 1.0,
+                msg="Function1D less equals scalar (f() <= K) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value <= self.f1)(x), 1.0,
+                msg="Scalar less equals Function1D (K <= f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= lower_value)(x), 0.0,
+                msg="Function1D less equals scalar (f() <= K) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value <= self.f1)(x), 0.0,
+                msg="Scalar less equals Function1D (K <= f()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= lower_value)(x), 1.0,
+                msg="Function1D greater equals scalar (f() >= K) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value >= self.f1)(x), 1.0,
+                msg="Scalar greater equals Function1D (K >= f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= ref_value)(x), 1.0,
+                msg="Function1D greater equals scalar (f() >= K) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value >= self.f1)(x), 1.0,
+                msg="Scalar greater equals Function1D (K >= f()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= higher_value)(x), 0.0,
+                msg="Function1D greater equals scalar (f() >= K) did not return false when it should."
+            )
+            self.assertEqual(
+                (lower_value >= self.f1)(x), 0.0,
+                msg="Scalar greater equals Function1D (K >= f()) did not return false when it should."
+            )
+
     def test_add_function1d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = self.f1 + self.f2
@@ -223,3 +342,198 @@ class TestFunction1D(unittest.TestCase):
             self.assertEqual(r4(x), math.fmod(self.ref2(x) ** self.ref1(x), self.ref2(x)), "Function1D 3 argument pow(f2(), f1(), f2()) did not match reference value.")
             self.assertEqual(r5(x), math.fmod(self.ref2(x) ** self.ref1(x), self.ref2(x)), "Function1D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
             self.assertEqual(r6(x), math.fmod(self.ref2(x) ** self.ref1(x), self.ref2(x)), "Function1D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
+
+    def test_abs(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.0003, 10, 2.3e49]
+        for x in v:
+            self.assertEqual(abs(self.f1)(x), abs(self.ref1(x)),
+                             msg="abs(Function1D) did not match reference value")
+
+    def test_richcmp_function_callable(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.ref1
+            higher_value = lambda x: self.ref1(x) + abs(self.ref1(x)) + 1
+            lower_value = lambda x: self.ref1(x) - abs(self.ref1(x)) - 1
+            self.assertEqual(
+                (self.f1 == ref_value)(x), 1.0,
+                msg="Function1D equals callable (f1() == f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 == higher_value)(x), 0.0,
+                msg="Function1D equals callable (f1() == f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 != higher_value)(x), 1.0,
+                msg="Function1D not equals callable (f1() != f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 != ref_value)(x), 0.0,
+                msg="Function1D not equals callable (f1() != f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 < higher_value)(x), 1.0,
+                msg="Function1D less than callable (f1() < f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 < lower_value)(x), 0.0,
+                msg="Function1D less than callable (f1() < f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 > lower_value)(x), 1.0,
+                msg="Function1D greater than callable (f1() > f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 > higher_value)(x), 0.0,
+                msg="Function1D greater than callable (f1() > f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= higher_value)(x), 1.0,
+                msg="Function1D less equals callable (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= ref_value)(x), 1.0,
+                msg="Function1D less equals callable (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= lower_value)(x), 0.0,
+                msg="Function1D less equals callable (f1() <= f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= lower_value)(x), 1.0,
+                msg="Function1D equals callable (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= ref_value)(x), 1.0,
+                msg="Function1D greater equals callable (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= higher_value)(x), 0.0,
+                msg="Function1D equals callable (f1() >= f2()) did not return false when it should."
+            )
+
+    def test_richcmp_callable_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.ref1
+            higher_value = lambda x: self.ref1(x) + abs(self.ref1(x)) + 1
+            lower_value = lambda x: self.ref1(x) - abs(self.ref1(x)) - 1
+            self.assertEqual(
+                (ref_value == self.f1)(x), 1.0,
+                msg="Callable equals Function1D (f1() == f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value == self.f1)(x), 0.0,
+                msg="Callable equals Function1D (f1() == f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value != self.f1)(x), 1.0,
+                msg="Callable not equals Function1D (f1() != f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value != self.f1)(x), 0.0,
+                msg="Callable not equals Function1D (f1() != f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (lower_value < self.f1)(x), 1.0,
+                msg="Callable less than Function1D (f1() < f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value < self.f1)(x), 0.0,
+                msg="Callable less than Function1D (f1() < f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value > self.f1)(x), 1.0,
+                msg="Callable greater than Function1D (f1() > f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (lower_value > self.f1)(x), 0.0,
+                msg="Callable greater than Function1D (f1() > f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (lower_value <= self.f1)(x), 1.0,
+                msg="Callable less equals Function1D (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value <= self.f1)(x), 1.0,
+                msg="Callable less equals Function1D (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (higher_value <= self.f1)(x), 0.0,
+                msg="Callable less equals Function1D (f1() <= f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (higher_value >= self.f1)(x), 1.0,
+                msg="Callable equals Function1D (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value >= self.f1)(x), 1.0,
+                msg="Callable greater equals Function1D (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (lower_value >= self.f1)(x), 0.0,
+                msg="Callable equals Function1D (f1() >= f2()) did not return false when it should."
+            )
+
+    def test_richcmp_function_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.f1
+            higher_value = self.f1 + abs(self.f1) + 1
+            lower_value = self.f1 - abs(self.f1) - 1
+            self.assertEqual(
+                (self.f1 == ref_value)(x), 1.0,
+                msg="Function1D equals Function1D (f1() == f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 == higher_value)(x), 0.0,
+                msg="Function1D equals Function1D (f1() == f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 != higher_value)(x), 1.0,
+                msg="Function1D not equals Function1D (f1() != f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 != ref_value)(x), 0.0,
+                msg="Function1D not equals Function1D (f1() != f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 < higher_value)(x), 1.0,
+                msg="Function1D less than Function1D (f1() < f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 < lower_value)(x), 0.0,
+                msg="Function1D less than Function1D (f1() < f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 > lower_value)(x), 1.0,
+                msg="Function1D greater than Function1D (f1() > f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 > higher_value)(x), 0.0,
+                msg="Function1D greater than Function1D (f1() > f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= higher_value)(x), 1.0,
+                msg="Function1D less equals Function1D (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= ref_value)(x), 1.0,
+                msg="Function1D less equals Function1D (f1() <= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 <= lower_value)(x), 0.0,
+                msg="Function1D less equals Function1D (f1() <= f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= lower_value)(x), 1.0,
+                msg="Function1D equals Function1D (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= ref_value)(x), 1.0,
+                msg="Function1D greater equals Function1D (f1() >= f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.f1 >= higher_value)(x), 0.0,
+                msg="Function1D equals Function1D (f1() >= f2()) did not return false when it should."
+            )

--- a/raysect/core/math/function/function2d/base.pxd
+++ b/raysect/core/math/function/function2d/base.pxd
@@ -58,6 +58,10 @@ cdef class PowFunction2D(Function2D):
     cdef Function2D _function1, _function2
 
 
+cdef class AbsFunction2D(Function2D):
+    cdef Function2D _function
+
+
 cdef class EqualsFunction2D(Function2D):
     cdef Function2D _function1, _function2
 

--- a/raysect/core/math/function/function2d/base.pxd
+++ b/raysect/core/math/function/function2d/base.pxd
@@ -58,6 +58,30 @@ cdef class PowFunction2D(Function2D):
     cdef Function2D _function1, _function2
 
 
+cdef class EqualsFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class NotEqualsFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class LessThanFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class GreaterThanFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class LessEqualsFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
+cdef class GreaterEqualsFunction2D(Function2D):
+    cdef Function2D _function1, _function2
+
+
 cdef class AddScalar2D(Function2D):
     cdef double _value
     cdef Function2D _function
@@ -98,11 +122,41 @@ cdef class PowFunctionScalar2D(Function2D):
     cdef Function2D _function
 
 
+cdef class EqualsScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class NotEqualsScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class LessThanScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class GreaterThanScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class LessEqualsScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
+cdef class GreaterEqualsScalar2D(Function2D):
+    cdef double _value
+    cdef Function2D _function
+
+
 cdef inline bint is_callable(object f):
     """
     Tests if an object is a python callable or function object.
-    
-    :param object f: Object to test.  
+
+    :param object f: Object to test.
     :return: True if callable, False otherwise.
     """
     return isinstance(f, Function2D) or callable(f)

--- a/raysect/core/math/function/function2d/base.pyx
+++ b/raysect/core/math/function/function2d/base.pyx
@@ -163,6 +163,9 @@ cdef class Function2D:
                 return PowScalarFunction2D(<double> a, b)
         return NotImplemented
 
+    def __abs__(self):
+        return AbsFunction2D(self)
+
     def __richcmp__(self, object other, int op):
         if is_callable(other):
             if op == Py_EQ:
@@ -320,6 +323,22 @@ cdef class PowFunction2D(Function2D):
         if base == 0 and exponent < 0:
             raise ZeroDivisionError("0.0 cannot be raised to a negative power")
         return base ** exponent
+
+
+cdef class AbsFunction2D(Function2D):
+    """
+    A Function2D class that implements the absolute value of the result of a Function2D object: abs(f()).
+
+    This class is not intended to be used directly, but rather returned as the
+    result of an __abs__() call on a Function2D object.
+
+    :param object function: A Function2D object or Python callable.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function2d(function)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+        return abs(self._function.evaluate(x, y))
 
 
 cdef class EqualsFunction2D(Function2D):

--- a/raysect/core/math/function/function2d/tests/test_base.py
+++ b/raysect/core/math/function/function2d/tests/test_base.py
@@ -359,6 +359,13 @@ class TestFunction2D(unittest.TestCase):
                 self.assertEqual(r5(x, y), math.fmod(self.ref2(x, y) ** self.ref1(x, y), self.ref2(x, y)), "Function2D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
                 self.assertEqual(r6(x, y), math.fmod(self.ref2(x, y) ** self.ref1(x, y), self.ref2(x, y)), "Function2D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
 
+    def test_abs(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.0003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                self.assertEqual(abs(self.f1)(x, y), abs(self.ref1(x, y)),
+                                 msg="abs(Function2D) did not match reference value")
+
     def test_richcmp_function_callable(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         for x in v:
@@ -492,13 +499,8 @@ class TestFunction2D(unittest.TestCase):
         for x in v:
             for y in v:
                 ref_value = self.f1
-                # Without Function2D.__abs__, manually ensure greater and less values are suitable
-                if self.f1(x, y) >= 0:
-                    higher_value = self.f1 + self.f1 + 1
-                    lower_value = self.f1 - self.f1 - 1
-                else:
-                    higher_value = self.f1 - self.f1 + 1
-                    lower_value = self.f1 + self.f1 - 1
+                higher_value = self.f1 + abs(self.f1) + 1
+                lower_value = self.f1 - abs(self.f1) - 1
                 self.assertEqual(
                     (self.f1 == ref_value)(x, y), 1.0,
                     msg="Function2D equals Function2D (f1() == f2()) did not return true when it should."

--- a/raysect/core/math/function/function2d/tests/test_base.py
+++ b/raysect/core/math/function/function2d/tests/test_base.py
@@ -137,6 +137,126 @@ class TestFunction2D(unittest.TestCase):
             r4 = 0 ** self.f1
             r4(-1, 0)
 
+    def test_richcmp_scalar(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                ref_value = self.ref1(x, y)
+                higher_value = ref_value + abs(ref_value) + 1
+                lower_value = ref_value - abs(ref_value) - 1
+                self.assertEqual(
+                    (self.f1 == ref_value)(x, y), 1.0,
+                    msg="Function2D equals scalar (f() == K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value == self.f1)(x, y), 1.0,
+                    msg="Scalar equals Function2D (K == f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 == higher_value)(x, y), 0.0,
+                    msg="Function2D equals scalar (f() == K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value == self.f1)(x, y), 0.0,
+                    msg="Scalar equals Function2D (K == f()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != higher_value)(x, y), 1.0,
+                    msg="Function2D not equals scalar (f() != K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value != self.f1)(x, y), 1.0,
+                    msg="Scalar not equals Function2D (K != f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != ref_value)(x, y), 0.0,
+                    msg="Function2D not equals scalar (f() != K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (ref_value != self.f1)(x, y), 0.0,
+                    msg="Scalar not equals Function2D (K != f()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < higher_value)(x, y), 1.0,
+                    msg="Function2D less than scalar (f() < K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (lower_value < self.f1)(x, y), 1.0,
+                    msg="Scalar less than Function2D (K < f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < lower_value)(x, y), 0.0,
+                    msg="Function2D less than scalar (f() < K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value < self.f1)(x, y), 0.0,
+                    msg="Scalar less than Function2D (K < f()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > lower_value)(x, y), 1.0,
+                    msg="Function2D greater than scalar (f() > K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value > self.f1)(x, y), 1.0,
+                    msg="Scalar greater than Function2D (K > f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > higher_value)(x, y), 0.0,
+                    msg="Function2D greater than scalar (f() > K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (lower_value > self.f1)(x, y), 0.0,
+                    msg="Scalar greater than Function2D (K > f()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= higher_value)(x, y), 1.0,
+                    msg="Function2D less equals scalar (f() <= K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (lower_value <= self.f1)(x, y), 1.0,
+                    msg="Scalar less equals Function2D (K <= f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= ref_value)(x, y), 1.0,
+                    msg="Function2D less equals scalar (f() <= K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value <= self.f1)(x, y), 1.0,
+                    msg="Scalar less equals Function2D (K <= f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= lower_value)(x, y), 0.0,
+                    msg="Function2D less equals scalar (f() <= K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value <= self.f1)(x, y), 0.0,
+                    msg="Scalar less equals Function2D (K <= f()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= lower_value)(x, y), 1.0,
+                    msg="Function2D greater equals scalar (f() >= K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value >= self.f1)(x, y), 1.0,
+                    msg="Scalar greater equals Function2D (K >= f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= ref_value)(x, y), 1.0,
+                    msg="Function2D greater equals scalar (f() >= K) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value >= self.f1)(x, y), 1.0,
+                    msg="Scalar greater equals Function2D (K >= f()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= higher_value)(x, y), 0.0,
+                    msg="Function2D greater equals scalar (f() >= K) did not return false when it should."
+                )
+                self.assertEqual(
+                    (lower_value >= self.f1)(x, y), 0.0,
+                    msg="Scalar greater equals Function2D (K >= f()) did not return false when it should."
+                )
+
     def test_add_function2d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = self.f1 + self.f2
@@ -238,3 +358,200 @@ class TestFunction2D(unittest.TestCase):
                 self.assertEqual(r4(x, y), math.fmod(self.ref2(x, y) ** self.ref1(x, y), self.ref2(x, y)), "Function2D 3 argument pow(f2(), f1(), f2()) did not match reference value.")
                 self.assertEqual(r5(x, y), math.fmod(self.ref2(x, y) ** self.ref1(x, y), self.ref2(x, y)), "Function2D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
                 self.assertEqual(r6(x, y), math.fmod(self.ref2(x, y) ** self.ref1(x, y), self.ref2(x, y)), "Function2D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
+
+    def test_richcmp_function_callable(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                ref_value = self.ref1
+                higher_value = lambda x, y: self.ref1(x, y) + abs(self.ref1(x, y)) + 1
+                lower_value = lambda x, y: self.ref1(x, y) - abs(self.ref1(x, y)) - 1
+                self.assertEqual(
+                    (self.f1 == ref_value)(x, y), 1.0,
+                    msg="Function2D equals callable (f1() == f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 == higher_value)(x, y), 0.0,
+                    msg="Function2D equals callable (f1() == f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != higher_value)(x, y), 1.0,
+                    msg="Function2D not equals callable (f1() != f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != ref_value)(x, y), 0.0,
+                    msg="Function2D not equals callable (f1() != f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < higher_value)(x, y), 1.0,
+                    msg="Function2D less than callable (f1() < f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < lower_value)(x, y), 0.0,
+                    msg="Function2D less than callable (f1() < f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > lower_value)(x, y), 1.0,
+                    msg="Function2D greater than callable (f1() > f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > higher_value)(x, y), 0.0,
+                    msg="Function2D greater than callable (f1() > f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= higher_value)(x, y), 1.0,
+                    msg="Function2D less equals callable (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= ref_value)(x, y), 1.0,
+                    msg="Function2D less equals callable (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= lower_value)(x, y), 0.0,
+                    msg="Function2D less equals callable (f1() <= f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= lower_value)(x, y), 1.0,
+                    msg="Function2D equals callable (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= ref_value)(x, y), 1.0,
+                    msg="Function2D greater equals callable (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= higher_value)(x, y), 0.0,
+                    msg="Function2D equals callable (f1() >= f2()) did not return false when it should."
+                )
+
+    def test_richcmp_callable_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                ref_value = self.ref1
+                higher_value = lambda x, y: self.ref1(x, y) + abs(self.ref1(x, y)) + 1
+                lower_value = lambda x, y: self.ref1(x, y) - abs(self.ref1(x, y)) - 1
+                self.assertEqual(
+                    (ref_value == self.f1)(x, y), 1.0,
+                    msg="Callable equals Function2D (f1() == f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value == self.f1)(x, y), 0.0,
+                    msg="Callable equals Function2D (f1() == f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value != self.f1)(x, y), 1.0,
+                    msg="Callable not equals Function2D (f1() != f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value != self.f1)(x, y), 0.0,
+                    msg="Callable not equals Function2D (f1() != f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (lower_value < self.f1)(x, y), 1.0,
+                    msg="Callable less than Function2D (f1() < f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value < self.f1)(x, y), 0.0,
+                    msg="Callable less than Function2D (f1() < f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value > self.f1)(x, y), 1.0,
+                    msg="Callable greater than Function2D (f1() > f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (lower_value > self.f1)(x, y), 0.0,
+                    msg="Callable greater than Function2D (f1() > f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (lower_value <= self.f1)(x, y), 1.0,
+                    msg="Callable less equals Function2D (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value <= self.f1)(x, y), 1.0,
+                    msg="Callable less equals Function2D (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (higher_value <= self.f1)(x, y), 0.0,
+                    msg="Callable less equals Function2D (f1() <= f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (higher_value >= self.f1)(x, y), 1.0,
+                    msg="Callable equals Function2D (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (ref_value >= self.f1)(x, y), 1.0,
+                    msg="Callable greater equals Function2D (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (lower_value >= self.f1)(x, y), 0.0,
+                    msg="Callable equals Function2D (f1() >= f2()) did not return false when it should."
+                )
+
+    def test_richcmp_function_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                ref_value = self.f1
+                # Without Function2D.__abs__, manually ensure greater and less values are suitable
+                if self.f1(x, y) >= 0:
+                    higher_value = self.f1 + self.f1 + 1
+                    lower_value = self.f1 - self.f1 - 1
+                else:
+                    higher_value = self.f1 - self.f1 + 1
+                    lower_value = self.f1 + self.f1 - 1
+                self.assertEqual(
+                    (self.f1 == ref_value)(x, y), 1.0,
+                    msg="Function2D equals Function2D (f1() == f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 == higher_value)(x, y), 0.0,
+                    msg="Function2D equals Function2D (f1() == f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != higher_value)(x, y), 1.0,
+                    msg="Function2D not equals Function2D (f1() != f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 != ref_value)(x, y), 0.0,
+                    msg="Function2D not equals Function2D (f1() != f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < higher_value)(x, y), 1.0,
+                    msg="Function2D less than Function2D (f1() < f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 < lower_value)(x, y), 0.0,
+                    msg="Function2D less than Function2D (f1() < f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > lower_value)(x, y), 1.0,
+                    msg="Function2D greater than Function2D (f1() > f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 > higher_value)(x, y), 0.0,
+                    msg="Function2D greater than Function2D (f1() > f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= higher_value)(x, y), 1.0,
+                    msg="Function2D less equals Function2D (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= ref_value)(x, y), 1.0,
+                    msg="Function2D less equals Function2D (f1() <= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 <= lower_value)(x, y), 0.0,
+                    msg="Function2D less equals Function2D (f1() <= f2()) did not return false when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= lower_value)(x, y), 1.0,
+                    msg="Function2D equals Function2D (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= ref_value)(x, y), 1.0,
+                    msg="Function2D greater equals Function2D (f1() >= f2()) did not return true when it should."
+                )
+                self.assertEqual(
+                    (self.f1 >= higher_value)(x, y), 0.0,
+                    msg="Function2D equals Function2D (f1() >= f2()) did not return false when it should."
+                )

--- a/raysect/core/math/function/function3d/base.pxd
+++ b/raysect/core/math/function/function3d/base.pxd
@@ -57,6 +57,34 @@ cdef class PowFunction3D(Function3D):
     cdef Function3D _function1, _function2
 
 
+cdef class AbsFunction3D(Function3D):
+    cdef Function3D _function
+
+
+cdef class EqualsFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class NotEqualsFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class LessThanFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class GreaterThanFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class LessEqualsFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class GreaterEqualsFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
 cdef class AddScalar3D(Function3D):
     cdef double _value
     cdef Function3D _function
@@ -97,11 +125,41 @@ cdef class PowFunctionScalar3D(Function3D):
     cdef Function3D _function
 
 
+cdef class EqualsScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class NotEqualsScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class LessThanScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class GreaterThanScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class LessEqualsScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
+cdef class GreaterEqualsScalar3D(Function3D):
+    cdef double _value
+    cdef Function3D _function
+
+
 cdef inline bint is_callable(object f):
     """
     Tests if an object is a python callable or function object.
-    
-    :param object f: Object to test.  
+
+    :param object f: Object to test.
     :return: True if callable, False otherwise.
     """
     return isinstance(f, Function3D) or callable(f)

--- a/raysect/core/math/function/function3d/tests/test_base.py
+++ b/raysect/core/math/function/function3d/tests/test_base.py
@@ -153,6 +153,127 @@ class TestFunction3D(unittest.TestCase):
             r4 = 0 ** self.f1
             r4(-1, 0, 0)
 
+    def test_richcmp_scalar(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.ref1(x, y, z)
+                    higher_value = ref_value + abs(ref_value) + 1
+                    lower_value = ref_value - abs(ref_value) - 1
+                    self.assertEqual(
+                        (self.f1 == ref_value)(x, y, z), 1.0,
+                        msg="Function3D equals scalar (f() == K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value == self.f1)(x, y, z), 1.0,
+                        msg="Scalar equals Function3D (K == f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 == higher_value)(x, y, z), 0.0,
+                        msg="Function3D equals scalar (f() == K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value == self.f1)(x, y, z), 0.0,
+                        msg="Scalar equals Function3D (K == f()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != higher_value)(x, y, z), 1.0,
+                        msg="Function3D not equals scalar (f() != K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value != self.f1)(x, y, z), 1.0,
+                        msg="Scalar not equals Function3D (K != f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != ref_value)(x, y, z), 0.0,
+                        msg="Function3D not equals scalar (f() != K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value != self.f1)(x, y, z), 0.0,
+                        msg="Scalar not equals Function3D (K != f()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < higher_value)(x, y, z), 1.0,
+                        msg="Function3D less than scalar (f() < K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value < self.f1)(x, y, z), 1.0,
+                        msg="Scalar less than Function3D (K < f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < lower_value)(x, y, z), 0.0,
+                        msg="Function3D less than scalar (f() < K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value < self.f1)(x, y, z), 0.0,
+                        msg="Scalar less than Function3D (K < f()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > lower_value)(x, y, z), 1.0,
+                        msg="Function3D greater than scalar (f() > K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value > self.f1)(x, y, z), 1.0,
+                        msg="Scalar greater than Function3D (K > f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > higher_value)(x, y, z), 0.0,
+                        msg="Function3D greater than scalar (f() > K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value > self.f1)(x, y, z), 0.0,
+                        msg="Scalar greater than Function3D (K > f()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= higher_value)(x, y, z), 1.0,
+                        msg="Function3D less equals scalar (f() <= K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value <= self.f1)(x, y, z), 1.0,
+                        msg="Scalar less equals Function3D (K <= f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= ref_value)(x, y, z), 1.0,
+                        msg="Function3D less equals scalar (f() <= K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value <= self.f1)(x, y, z), 1.0,
+                        msg="Scalar less equals Function3D (K <= f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= lower_value)(x, y, z), 0.0,
+                        msg="Function3D less equals scalar (f() <= K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value <= self.f1)(x, y, z), 0.0,
+                        msg="Scalar less equals Function3D (K <= f()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= lower_value)(x, y, z), 1.0,
+                        msg="Function3D greater equals scalar (f() >= K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value >= self.f1)(x, y, z), 1.0,
+                        msg="Scalar greater equals Function3D (K >= f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= ref_value)(x, y, z), 1.0,
+                        msg="Function3D greater equals scalar (f() >= K) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value >= self.f1)(x, y, z), 1.0,
+                        msg="Scalar greater equals Function3D (K >= f()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= higher_value)(x, y, z), 0.0,
+                        msg="Function3D greater equals scalar (f() >= K) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value >= self.f1)(x, y, z), 0.0,
+                        msg="Scalar greater equals Function3D (K >= f()) did not return false when it should."
+                    )
+
     def test_add_function3d(self):
         v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = self.f1 + self.f2
@@ -262,3 +383,206 @@ class TestFunction3D(unittest.TestCase):
                     self.assertEqual(r4(x, y, z), math.fmod(self.ref2(x, y, z) ** self.ref1(x, y, z), self.ref2(x, y, z)), "Function3D 3 argument pow(f2(), f1(), f2()) did not match reference value.")
                     self.assertEqual(r5(x, y, z), math.fmod(self.ref2(x, y, z) ** self.ref1(x, y, z), self.ref2(x, y, z)), "Function3D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
                     self.assertEqual(r6(x, y, z), math.fmod(self.ref2(x, y, z) ** self.ref1(x, y, z), self.ref2(x, y, z)), "Function3D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
+
+    def test_abs(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.0003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(abs(self.f1)(x, y, z), abs(self.ref1(x, y, z)),
+                                     msg="abs(Function3D) did not match reference value")
+
+    def test_richcmp_function_callable(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.ref1
+                    higher_value = lambda x, y, z: self.ref1(x, y, z) + abs(self.ref1(x, y, z)) + 1
+                    lower_value = lambda x, y, z: self.ref1(x, y, z) - abs(self.ref1(x, y, z)) - 1
+                    self.assertEqual(
+                        (self.f1 == ref_value)(x, y, z), 1.0,
+                        msg="Function3D equals callable (f1() == f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 == higher_value)(x, y, z), 0.0,
+                        msg="Function3D equals callable (f1() == f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != higher_value)(x, y, z), 1.0,
+                        msg="Function3D not equals callable (f1() != f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != ref_value)(x, y, z), 0.0,
+                        msg="Function3D not equals callable (f1() != f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < higher_value)(x, y, z), 1.0,
+                        msg="Function3D less than callable (f1() < f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < lower_value)(x, y, z), 0.0,
+                        msg="Function3D less than callable (f1() < f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > lower_value)(x, y, z), 1.0,
+                        msg="Function3D greater than callable (f1() > f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > higher_value)(x, y, z), 0.0,
+                        msg="Function3D greater than callable (f1() > f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= higher_value)(x, y, z), 1.0,
+                        msg="Function3D less equals callable (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= ref_value)(x, y, z), 1.0,
+                        msg="Function3D less equals callable (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= lower_value)(x, y, z), 0.0,
+                        msg="Function3D less equals callable (f1() <= f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= lower_value)(x, y, z), 1.0,
+                        msg="Function3D equals callable (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= ref_value)(x, y, z), 1.0,
+                        msg="Function3D greater equals callable (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= higher_value)(x, y, z), 0.0,
+                        msg="Function3D equals callable (f1() >= f2()) did not return false when it should."
+                    )
+
+    def test_richcmp_callable_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.ref1
+                    higher_value = lambda x, y, z: self.ref1(x, y, z) + abs(self.ref1(x, y, z)) + 1
+                    lower_value = lambda x, y, z: self.ref1(x, y, z) - abs(self.ref1(x, y, z)) - 1
+                    self.assertEqual(
+                        (ref_value == self.f1)(x, y, z), 1.0,
+                        msg="Callable equals Function3D (f1() == f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value == self.f1)(x, y, z), 0.0,
+                        msg="Callable equals Function3D (f1() == f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value != self.f1)(x, y, z), 1.0,
+                        msg="Callable not equals Function3D (f1() != f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value != self.f1)(x, y, z), 0.0,
+                        msg="Callable not equals Function3D (f1() != f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value < self.f1)(x, y, z), 1.0,
+                        msg="Callable less than Function3D (f1() < f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value < self.f1)(x, y, z), 0.0,
+                        msg="Callable less than Function3D (f1() < f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value > self.f1)(x, y, z), 1.0,
+                        msg="Callable greater than Function3D (f1() > f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value > self.f1)(x, y, z), 0.0,
+                        msg="Callable greater than Function3D (f1() > f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value <= self.f1)(x, y, z), 1.0,
+                        msg="Callable less equals Function3D (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value <= self.f1)(x, y, z), 1.0,
+                        msg="Callable less equals Function3D (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value <= self.f1)(x, y, z), 0.0,
+                        msg="Callable less equals Function3D (f1() <= f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (higher_value >= self.f1)(x, y, z), 1.0,
+                        msg="Callable equals Function3D (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value >= self.f1)(x, y, z), 1.0,
+                        msg="Callable greater equals Function3D (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (lower_value >= self.f1)(x, y, z), 0.0,
+                        msg="Callable equals Function3D (f1() >= f2()) did not return false when it should."
+                    )
+
+    def test_richcmp_function_function(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.f1
+                    higher_value = self.f1 + abs(self.f1) + 1
+                    lower_value = self.f1 - abs(self.f1) - 1
+                    self.assertEqual(
+                        (self.f1 == ref_value)(x, y, z), 1.0,
+                        msg="Function3D equals Function3D (f1() == f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 == higher_value)(x, y, z), 0.0,
+                        msg="Function3D equals Function3D (f1() == f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != higher_value)(x, y, z), 1.0,
+                        msg="Function3D not equals Function3D (f1() != f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 != ref_value)(x, y, z), 0.0,
+                        msg="Function3D not equals Function3D (f1() != f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < higher_value)(x, y, z), 1.0,
+                        msg="Function3D less than Function3D (f1() < f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 < lower_value)(x, y, z), 0.0,
+                        msg="Function3D less than Function3D (f1() < f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > lower_value)(x, y, z), 1.0,
+                        msg="Function3D greater than Function3D (f1() > f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 > higher_value)(x, y, z), 0.0,
+                        msg="Function3D greater than Function3D (f1() > f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= higher_value)(x, y, z), 1.0,
+                        msg="Function3D less equals Function3D (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= ref_value)(x, y, z), 1.0,
+                        msg="Function3D less equals Function3D (f1() <= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 <= lower_value)(x, y, z), 0.0,
+                        msg="Function3D less equals Function3D (f1() <= f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= lower_value)(x, y, z), 1.0,
+                        msg="Function3D equals Function3D (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= ref_value)(x, y, z), 1.0,
+                        msg="Function3D greater equals Function3D (f1() >= f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.f1 >= higher_value)(x, y, z), 0.0,
+                        msg="Function3D equals Function3D (f1() >= f2()) did not return false when it should."
+                    )


### PR DESCRIPTION
Enable arithmetic comparison operations between FunctionxD objects,
which return 1.0 if the comparison returns True, or 0.0 if the
comparison returns false.

At the moment I've only implemented the 2D operators, so we can discuss the implementation before I go ahead and add the 1D and 3D ones. The pull request would end up being too large to properly review otherwise.

Also, should these features still be based off the feature/function branch? Or is the function framework sufficiently stable that we can add new functions straight to the development branch?