### PR TITLE
Spectral adaptive samplers

### DIFF
--- a/docs/source/api_reference/optical/pipelines.rst
+++ b/docs/source/api_reference/optical/pipelines.rst
@@ -61,6 +61,9 @@ Power
 .. autoclass:: raysect.optical.observer.pipeline.mono.PowerPipeline0D
    :show-inheritance:
 
+.. autoclass:: raysect.optical.observer.pipeline.mono.PowerPipeline1D
+   :show-inheritance:
+
 .. autoclass:: raysect.optical.observer.pipeline.mono.PowerPipeline2D
    :members: display_auto_exposure, display_unsaturated_fraction, display_update_time, save
    :show-inheritance:
@@ -70,6 +73,9 @@ Radiance
 --------
 
 .. autoclass:: raysect.optical.observer.pipeline.mono.RadiancePipeline0D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.pipeline.mono.RadiancePipeline1D
    :show-inheritance:
 
 .. autoclass:: raysect.optical.observer.pipeline.mono.RadiancePipeline2D
@@ -86,6 +92,13 @@ Spectral
    :members: to_spectrum
    :show-inheritance:
 
+.. autoclass:: raysect.optical.observer.pipeline.spectral.SpectralPowerPipeline1D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.pipeline.spectral.SpectralRadiancePipeline1D
+   :members: to_spectrum
+   :show-inheritance:
+
 .. autoclass:: raysect.optical.observer.pipeline.spectral.SpectralPowerPipeline2D
    :show-inheritance:
 
@@ -97,11 +110,35 @@ Spectral
 Frame Samplers
 --------------
 
+.. autoclass:: raysect.optical.observer.sampler1d.FullFrameSampler1D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler1d.MonoAdaptiveSampler1D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler1d.SpectralAdaptiveSampler1D
+   :show-inheritance:
+
 .. autoclass:: raysect.optical.observer.sampler2d.FullFrameSampler2D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler2d.MaskedFrameSampler2D
    :show-inheritance:
 
 .. autoclass:: raysect.optical.observer.sampler2d.MonoAdaptiveSampler2D
    :show-inheritance:
 
+.. autoclass:: raysect.optical.observer.sampler2d.MaskedMonoAdaptiveSampler2D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler2d.SpectralAdaptiveSampler2D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler2d.MaskedSpectralAdaptiveSampler2D
+   :show-inheritance:
+
 .. autoclass:: raysect.optical.observer.sampler2d.RGBAdaptiveSampler2D
+   :show-inheritance:
+
+.. autoclass:: raysect.optical.observer.sampler2d.MaskedRGBAdaptiveSampler2D
    :show-inheritance:

--- a/raysect/optical/observer/sampler1d.pyx
+++ b/raysect/optical/observer/sampler1d.pyx
@@ -31,8 +31,8 @@ import numpy as np
 from random import shuffle
 
 from raysect.optical.observer.base cimport FrameSampler1D
-from raysect.optical.observer.pipeline cimport RadiancePipeline1D, PowerPipeline1D
-from raysect.core.math cimport StatsArray1D
+from raysect.optical.observer.pipeline cimport RadiancePipeline1D, PowerPipeline1D, SpectralRadiancePipeline1D, SpectralPowerPipeline1D
+from raysect.core.math cimport StatsArray1D, StatsArray2D
 cimport numpy as np
 cimport cython
 
@@ -66,7 +66,10 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     :param PowerPipeline1D pipeline: The specific power pipeline to use for feedback control.
     :param float fraction: The fraction of frame pixels to receive extra sampling
       (default=0.2).
-    :param float ratio:
+    :param float ratio: The maximum allowable ratio between the maximum and minimum number of
+      samples obtained for the pixels of the same observer (default=10).
+      The sampler will generate additional tasks for pixels with the least number of samples
+      in order to keep this ratio below a given value.
     :param int min_samples: Minimum number of pixel samples across the image before
       turning on adaptive sampling (default=1000).
     :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
@@ -75,21 +78,67 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     """
 
     cdef:
-        PowerPipeline1D pipeline
-        double fraction, ratio, cutoff
-        int min_samples
+        PowerPipeline1D _pipeline
+        double _fraction, _ratio, _cutoff
+        int _min_samples
 
     def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0):
 
-        if not isinstance(pipeline, (PowerPipeline1D, RadiancePipeline1D)):
-            raise TypeError('Sampler only compatible with PowerPipeLine1D or RadiancePipeline1D pipelines.')
-
-        # todo: validation
         self.pipeline = pipeline
         self.fraction = fraction
         self.ratio = ratio
         self.min_samples = min_samples
         self.cutoff = cutoff
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (PowerPipeline1D, RadiancePipeline1D)):
+            raise TypeError('Sampler only compatible with PowerPipeLine1D or RadiancePipeline1D pipelines.')
+        self._pipeline = value
+
+    @property
+    def fraction(self):
+        return self._fraction
+
+    @fraction.setter
+    def fraction(self, value):
+        if value <= 0 or value > 1.:
+            raise ValueError("fraction must be in the range (0, 1]")
+        self._fraction = value
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        if value < 1.:
+            raise ValueError("ratio must be >= 1")
+        self._ratio = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -97,7 +146,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
 
         cdef:
             StatsArray1D frame
-            int pixel
+            int pixel, min_samples
             np.ndarray normalised
             double[::1] error, normalised_mv
             double percentile_error
@@ -112,7 +161,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
         if pixels != frame.length:
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
 
-        min_samples = max(self.min_samples, frame.samples.max() / self.ratio)
+        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
         error = frame.errors()
         normalised = np.zeros(frame.length)
         normalised_mv = normalised
@@ -153,3 +202,213 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
 
         return tasks
 
+
+cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
+    """
+    FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
+    level in each pixel's power value.
+
+    Pixels that have high noise levels will receive extra samples until the desired
+    noise threshold is achieve across the whole image.
+
+    :param SpectralPowerPipeline1D pipeline: The specific spectral power pipeline to use
+      for feedback control.
+    :param float fraction: The fraction of frame pixels to receive extra sampling
+      (default=0.2).
+    :param float ratio: The maximum allowable ratio between the maximum and minimum number of
+      samples obtained for the pixels of the same observer (default=10).
+      The sampler will generate additional tasks for pixels with the least number of samples
+      in order to keep this ratio below a given value.
+    :param int min_samples: Minimum number of pixel samples across the image before
+      turning on adaptive sampling (default=1000).
+    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
+      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
+      cutoff of 0.01 corresponds to 1% standard error.
+    :param str reduction_method: A method for obtaining spectral-average value of normalised
+      error of a pixel from spectral array of errors (default='percentile').
+       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+         average of the spectral errors,
+       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+         of the spectral errors excluding spectral bins with zero power,
+       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+         percentile of the spectral errors excluding spectral bins with zero power.
+    :param double percentile: If `reduction_method='percentile'`, defines the percentile of
+      statistical errors of spectral bins with non-zero power, which is used to calculate
+      normalised error of a pixel (default=100). If `percentile=x`, extra sampling will be aborted
+      if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
+    """
+
+    cdef:
+        SpectralPowerPipeline1D _pipeline
+        str _reduction_method
+        double _fraction, _ratio, _cutoff, _percentile
+        int _min_samples
+
+    def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0,
+                 str reduction_method='percentile', double percentile=100.):
+
+        self.pipeline = pipeline
+        self.fraction = fraction
+        self.ratio = ratio
+        self.min_samples = min_samples
+        self.cutoff = cutoff
+        self.reduction_method = reduction_method
+        self.percentile = percentile
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (SpectralPowerPipeline1D, SpectralRadiancePipeline1D)):
+            raise TypeError('Sampler only compatible with SpectralPowerPipeLine1D or SpectralRadiancePipeline1D pipelines.')
+        self._pipeline = value
+
+    @property
+    def fraction(self):
+        return self._fraction
+
+    @fraction.setter
+    def fraction(self, value):
+        if value <= 0 or value > 1.:
+            raise ValueError("fraction must be in the range (0, 1]")
+        self._fraction = value
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        if value < 1.:
+            raise ValueError("ratio must be >= 1")
+        self._ratio = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
+
+    @property
+    def reduction_method(self):
+        return self._reduction_method
+
+    @reduction_method.setter
+    def reduction_method(self, value):
+        if value not in {'weighted', 'mean', 'percentile'}:
+            raise ValueError("reduction_method must be 'weighted', 'mean' or 'percentile'")
+        self._reduction_method = value
+
+    @property
+    def percentile(self):
+        return self._percentile
+
+    @percentile.setter
+    def percentile(self, value):
+        if value < 0 or value > 100.:
+            raise ValueError("Percentiles must be in the range [0, 100]")
+        self._percentile = value
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef list generate_tasks(self, int pixels):
+
+        cdef:
+            StatsArray2D frame
+            int pixel, sbin, count, min_samples
+            np.ndarray normalised, spectral_normalised
+            double[::1] normalised_mv, spectral_normalised_mv
+            double[:, ::1] error
+            double percentile_error, pixel_power
+            list tasks
+
+        frame = self.pipeline.frame
+        if frame is None:
+            # no frame data available, generate tasks for the full frame
+            return self._full_frame(pixels)
+
+        # sanity check
+        if pixels != frame.nx:
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
+
+        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
+        error = frame.errors()
+        normalised = np.zeros(frame.nx)
+        normalised_mv = normalised
+
+        # calculated normalised standard error
+        if self.reduction_method == 'weighted':
+            for pixel in range(frame.nx):
+                pixel_power = 0
+                for sbin in range(frame.ny):
+                    if frame.mean_mv[pixel, sbin] > 0:
+                        normalised_mv[pixel] += error[pixel, sbin]
+                        pixel_power += frame.mean_mv[pixel, sbin]
+                if pixel_power:
+                    normalised_mv[pixel] /= pixel_power
+
+        elif self.reduction_method == 'mean':
+            for pixel in range(frame.nx):
+                count = 0
+                for sbin in range(frame.ny):
+                    if frame.mean_mv[pixel, sbin] > 0:
+                        normalised_mv[pixel] += error[pixel, sbin] / frame.mean_mv[pixel, sbin]
+                        count += 1
+                if count:
+                    normalised_mv[pixel] /= count
+        else:
+            spectral_normalised = np.zeros(frame.ny)
+            spectral_normalised_mv = spectral_normalised
+            for pixel in range(frame.nx):
+                count = 0
+                for sbin in range(frame.ny):
+                    if frame.mean_mv[pixel, sbin] > 0:
+                        spectral_normalised_mv[count] = error[pixel, sbin] / frame.mean_mv[pixel, sbin]
+                        count += 1
+                if count:
+                    normalised_mv[pixel] = np.percentile(spectral_normalised[:count], self.percentile)
+
+        # locate error value corresponding to fraction of frame to process
+        percentile_error = np.percentile(normalised, (1 - self.fraction) * 100)
+
+        # build tasks
+        tasks = []
+        for pixel in range(frame.nx):
+            if frame.samples[pixel].min() < min_samples or normalised_mv[pixel] > max(self.cutoff, percentile_error):
+                tasks.append((pixel, ))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+    cpdef list _full_frame(self, int pixels):
+
+        cdef:
+            list tasks
+            int pixel
+
+        tasks = []
+        for pixel in range(pixels):
+            tasks.append((pixel, ))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks

--- a/raysect/optical/observer/sampler1d.pyx
+++ b/raysect/optical/observer/sampler1d.pyx
@@ -231,21 +231,21 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
       cutoff of 0.01 corresponds to 1% standard error.
     :param str reduction_method: A method for obtaining spectral-average value of normalised
       error of a pixel from spectral array of errors (default='percentile').
-        - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
-          average of the spectral errors,
-        - `reduction_method='mean'`: the error of a pixel is calculated as a mean
-          of the spectral errors excluding spectral bins with zero power,
-        - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
-          percentile of the spectral errors excluding spectral bins with zero power.
-        - `reduction_method='power_percentile'`: the error of a pixel is calculated as the highest
-          spectral error among a given percentage of spectral bins with the highest spectral power.
+       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+         average of the spectral errors,
+       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+         of the spectral errors excluding spectral bins with zero power,
+       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+         percentile of the spectral errors excluding spectral bins with zero power.
+       - `reduction_method='power_percentile'`: the error of a pixel is calculated as the highest
+         spectral error among a given percentage of spectral bins with the highest spectral power.
     :param double percentile: Used only if `reduction_method='percentile'` or
       `reduction_method='power_percentile'` (default=100).
-        - `reduction_method='percentile'`: If `percentile=x`, extra sampling will be aborted
-        if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
-        - `reduction_method='power_percentile'`: If `percentile=x`, extra sampling will be aborted
-        if `x`% of spectral bins with the highest spectral power have normalised error lower
-        than `cutoff`.
+       - `reduction_method='percentile'`: If `percentile=x`, extra sampling will be aborted
+         if x% of spectral bins of each pixel have normalised errors lower than `cutoff`.
+       - `reduction_method='power_percentile'`: If `percentile=x`, extra sampling will be aborted
+         if x% of spectral bins with the highest spectral power all have normalised errors lower
+         than `cutoff`.
     """
 
     cdef:

--- a/raysect/optical/observer/sampler1d.pyx
+++ b/raysect/optical/observer/sampler1d.pyx
@@ -107,7 +107,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("Parameter 'fraction' must be in the range (0, 1]")
+            raise ValueError("Parameter 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -117,7 +117,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("Parameter 'ratio' must be >= 1")
+            raise ValueError("Parameter 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -127,7 +127,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("Parameter 'min_samples' must be >= 1")
+            raise ValueError("Parameter 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -137,7 +137,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("Parameter 'cutoff' must be in the range [0, 1]")
+            raise ValueError("Parameter 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @cython.boundscheck(False)
@@ -282,7 +282,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("Attribute 'fraction' must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -292,7 +292,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("Attribute 'ratio' must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -302,7 +302,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("Attribute 'min_samples' must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -312,7 +312,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("Attribute 'cutoff' must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @property
@@ -322,7 +322,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @reduction_method.setter
     def reduction_method(self, value):
         if value not in {'weighted', 'mean', 'percentile', 'power_percentile'}:
-            raise ValueError("Attribute 'reduction_method' must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
+            raise ValueError("Attribute 'reduction_method' must be 'weighted', 'mean', 'percentile' or 'power_percentile'.")
         self._reduction_method = value
 
     @property
@@ -332,7 +332,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
     @percentile.setter
     def percentile(self, value):
         if value < 0 or value > 100.:
-            raise ValueError("Percentiles must be in the range [0, 100]")
+            raise ValueError("Percentiles must be in the range [0, 100].")
         self._percentile = value
 
     @cython.boundscheck(False)
@@ -375,7 +375,7 @@ cdef class SpectralAdaptiveSampler1D(FrameSampler1D):
 
         else:
             raise ValueError("Attribute 'reduction_method' has wrong value: %s. " % self._reduction_method +
-                             "Must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
+                             "Must be 'weighted', 'mean', 'percentile' or 'power_percentile'.")
 
         normalised_mv = normalised
 

--- a/raysect/optical/observer/sampler1d.pyx
+++ b/raysect/optical/observer/sampler1d.pyx
@@ -107,7 +107,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("Parameter 'fraction' must be in the range (0, 1].")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -117,7 +117,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("Parameter 'ratio' must be >= 1.")
+            raise ValueError("Attribute 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -127,7 +127,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("Parameter 'min_samples' must be >= 1.")
+            raise ValueError("Attribute 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -137,7 +137,7 @@ cdef class MonoAdaptiveSampler1D(FrameSampler1D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("Parameter 'cutoff' must be in the range [0, 1].")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @cython.boundscheck(False)

--- a/raysect/optical/observer/sampler2d.pyx
+++ b/raysect/optical/observer/sampler2d.pyx
@@ -31,8 +31,9 @@ import numpy as np
 from random import shuffle
 
 from raysect.optical.observer.base cimport FrameSampler2D
-from raysect.optical.observer.pipeline cimport RGBPipeline2D, RadiancePipeline2D, PowerPipeline2D
+from raysect.optical.observer.pipeline cimport RGBPipeline2D, RadiancePipeline2D, PowerPipeline2D, SpectralRadiancePipeline2D, SpectralPowerPipeline2D
 from raysect.core.math cimport StatsArray1D, StatsArray2D, StatsArray3D
+from timeit import default_timer as timer
 cimport numpy as np
 cimport cython
 
@@ -58,6 +59,54 @@ cdef class FullFrameSampler2D(FrameSampler2D):
         return tasks
 
 
+cdef class MaskedFrameSampler2D(FrameSampler2D):
+    """
+    Evenly samples the masked 2D frame.
+
+    :param np.ndarray mask: The image mask array.
+    """
+
+    cdef:
+        np.ndarray _mask
+
+    def __init__(self, np.ndarray mask):
+
+        self.mask = mask
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, np.ndarray value):
+        if value.ndim != 2:
+            raise ValueError("Mask must be a 2D array")
+        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
+            raise TypeError("Mask must be an array of booleans or integers")
+        self._mask = value
+
+    cpdef list generate_tasks(self, tuple pixels):
+
+        cdef:
+            list tasks
+            int nx, ny
+
+        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
+
+        tasks = []
+        nx, ny = pixels
+        for iy in range(ny):
+            for ix in range(nx):
+                if self.mask[ix, iy]:
+                    tasks.append((ix, iy))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+
 cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     """
     FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
@@ -69,7 +118,10 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     :param PowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
     :param float fraction: The fraction of frame pixels to receive extra sampling
       (default=0.2).
-    :param float ratio:
+    :param float ratio: The maximum allowable ratio between the maximum and minimum number of
+      samples obtained for the pixels of the same observer (default=10).
+      The sampler will generate additional tasks for pixels with the least number of samples
+      in order to keep this ratio below a given value.
     :param int min_samples: Minimum number of pixel samples across the image before
       turning on adaptive sampling (default=1000).
     :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
@@ -78,21 +130,67 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     """
 
     cdef:
-        PowerPipeline2D pipeline
-        double fraction, ratio, cutoff
-        int min_samples
+        PowerPipeline2D _pipeline
+        double _fraction, _ratio, _cutoff
+        int _min_samples
 
     def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0):
 
-        if not isinstance(pipeline, (PowerPipeline2D, RadiancePipeline2D)):
-            raise TypeError('Sampler only compatible with PowerPipeLine2D or RadiancePipeline2D pipelines.')
-
-        # todo: validation
         self.pipeline = pipeline
         self.fraction = fraction
         self.ratio = ratio
         self.min_samples = min_samples
         self.cutoff = cutoff
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (PowerPipeline2D, RadiancePipeline2D)):
+            raise TypeError('Sampler only compatible with PowerPipeLine2D or RadiancePipeline2D pipelines.')
+        self._pipeline = value
+
+    @property
+    def fraction(self):
+        return self._fraction
+
+    @fraction.setter
+    def fraction(self, value):
+        if value <= 0 or value > 1.:
+            raise ValueError("fraction must be in the range (0, 1]")
+        self._fraction = value
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        if value < 1.:
+            raise ValueError("ratio must be >= 1")
+        self._ratio = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -100,9 +198,9 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
 
         cdef:
             StatsArray2D frame
-            int x, y
+            int x, y, min_samples
             np.ndarray normalised
-            double[:,::1] error, normalised_mv
+            double[:, ::1] error, normalised_mv
             double percentile_error
             list tasks
 
@@ -115,7 +213,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
         if pixels != frame.shape:
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
 
-        min_samples = max(self.min_samples, frame.samples.max() / self.ratio)
+        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
         error = frame.errors()
         normalised = np.zeros((frame.nx, frame.ny))
         normalised_mv = normalised
@@ -179,21 +277,59 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
     """
 
     cdef:
-        PowerPipeline2D pipeline
-        double fraction, ratio, cutoff
-        int min_samples
-        np.ndarray mask
+        PowerPipeline2D _pipeline
+        double _cutoff
+        int _min_samples
+        np.ndarray _mask
 
     def __init__(self, object pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0):
 
-        if not isinstance(pipeline, (PowerPipeline2D, RadiancePipeline2D)):
-            raise TypeError('Sampler only compatible with PowerPipeLine2D or RadiancePipeline2D pipelines.')
-
-        # todo: validation
         self.pipeline = pipeline
         self.min_samples = min_samples
         self.cutoff = cutoff
         self.mask = mask
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (PowerPipeline2D, RadiancePipeline2D)):
+            raise TypeError('Sampler only compatible with PowerPipeLine2D or RadiancePipeline2D pipelines.')
+        self._pipeline = value
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, np.ndarray value):
+        if value.ndim != 2:
+            raise ValueError("Mask must be a 2D array")
+        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
+            raise TypeError("Mask must be an array of booleans or integers")
+        self._mask = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -204,8 +340,10 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
             int x, y
             np.ndarray normalised
             double[:,::1] error, normalised_mv
-            double percentile_error
             list tasks
+
+        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
 
         frame = self.pipeline.frame
         if frame is None:
@@ -216,10 +354,6 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
         if pixels != frame.shape:
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
 
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
-            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
-
-        min_samples = self.min_samples
         error = frame.errors()
         normalised = np.zeros((frame.nx, frame.ny))
         normalised_mv = normalised
@@ -236,7 +370,428 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
         tasks = []
         for x in range(frame.nx):
             for y in range(frame.ny):
-                if self.mask[x, y] and (frame.samples_mv[x, y] < min_samples or normalised_mv[x, y] > self.cutoff):
+                if self.mask[x, y] and (frame.samples_mv[x, y] < self.min_samples or normalised_mv[x, y] > self.cutoff):
+                    tasks.append((x, y))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+    cpdef list _full_frame(self, tuple pixels):
+
+        cdef:
+            list tasks
+            int nx, ny, x, y
+
+        tasks = []
+        nx, ny = pixels
+        for x in range(nx):
+            for y in range(ny):
+                if self.mask[x, y]:
+                    tasks.append((x, y))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+
+cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
+    """
+    FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
+    level in each pixel's power value.
+
+    Pixels that have high noise levels will receive extra samples until the desired
+    noise threshold is achieve across the whole image.
+
+    :param SpectralPowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
+    :param float fraction: The fraction of frame pixels to receive extra sampling
+      (default=0.2).
+    :param float ratio: The maximum allowable ratio between the maximum and minimum number of
+      samples obtained for the pixels of the same observer (default=10).
+      The sampler will generate additional tasks for pixels with the least number of samples
+      in order to keep this ratio below a given value.
+    :param int min_samples: Minimum number of pixel samples across the image before
+      turning on adaptive sampling (default=1000).
+    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
+      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
+      cutoff of 0.01 corresponds to 1% standard error.
+    :param str reduction_method: A method for obtaining spectral-average value of normalised
+      error of a pixel from spectral array of errors (default='percentile'). 
+       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+         average of the spectral errors,
+       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+         of the spectral errors excluding spectral bins with zero power,
+       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+         percentile of the spectral errors excluding spectral bins with zero power.
+    :param double percentile: If `reduction_method='percentile'`, defines the percentile of
+      statistical errors of spectral bins with non-zero power, which is used to calculate
+      normalised error of a pixel (default=100). If `percentile=x`, extra sampling will be aborted
+      if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
+    """
+
+    cdef:
+        SpectralPowerPipeline2D _pipeline
+        double _fraction, _ratio, _cutoff, _percentile
+        str _reduction_method
+        int _min_samples
+
+    def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0,
+                 str reduction_method='percentile', double percentile=100.):
+
+        self.pipeline = pipeline
+        self.fraction = fraction
+        self.ratio = ratio
+        self.min_samples = min_samples
+        self.cutoff = cutoff
+        self.reduction_method = reduction_method
+        self.percentile = percentile
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (SpectralPowerPipeline2D, SpectralRadiancePipeline2D)):
+            raise TypeError('Sampler only compatible with SpectralPowerPipeLine2D or SpectralRadiancePipeline2D pipelines.')
+        self._pipeline = value
+
+    @property
+    def fraction(self):
+        return self._fraction
+
+    @fraction.setter
+    def fraction(self, value):
+        if value <= 0 or value > 1.:
+            raise ValueError("fraction must be in the range (0, 1]")
+        self._fraction = value
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        if value < 1.:
+            raise ValueError("ratio must be >= 1")
+        self._ratio = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
+
+    @property
+    def reduction_method(self):
+        return self._reduction_method
+
+    @reduction_method.setter
+    def reduction_method(self, value):
+        if value not in {'weighted', 'mean', 'percentile'}:
+            raise ValueError("reduction_method must be 'weighted', 'mean' or 'percentile'")
+        self._reduction_method = value
+
+    @property
+    def percentile(self):
+        return self._percentile
+
+    @percentile.setter
+    def percentile(self, value):
+        if value < 0 or value > 100.:
+            raise ValueError("Percentiles must be in the range [0, 100]")
+        self._percentile = value
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef list generate_tasks(self, tuple pixels):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z, count, min_samples
+            np.ndarray normalised, spectral_normalised
+            double[::1] spectral_normalised_mv
+            double[:, ::1] normalised_mv
+            double[:, :, ::1] error
+            double percentile_error, pixel_power
+            list tasks
+
+        frame = self.pipeline.frame
+        if frame is None:
+            # no frame data available, generate tasks for the full frame
+            return self._full_frame(pixels)
+
+        # sanity check
+        if pixels != (frame.nx, frame.ny):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
+
+        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
+        error = frame.errors()
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+
+        # calculated normalised standard error
+        if self.reduction_method == 'weighted':
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    pixel_power = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z]
+                            pixel_power += frame.mean_mv[x, y, z]
+                    if pixel_power:
+                        normalised_mv[x, y] /= pixel_power
+
+        elif self.reduction_method == 'mean':
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    count = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z] / frame.mean_mv[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] /= count
+        else:
+            spectral_normalised = np.zeros(frame.nz)
+            spectral_normalised_mv = spectral_normalised
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    count = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            spectral_normalised_mv[count] = error[x, y, z] / frame.mean_mv[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] = np.percentile(spectral_normalised[:count], self.percentile)
+
+        # locate error value corresponding to fraction of frame to process
+        percentile_error = np.percentile(normalised, (1 - self.fraction) * 100)
+
+        # build tasks
+        tasks = []
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if frame.samples[x, y].min() < min_samples or normalised_mv[x, y] > max(self.cutoff, percentile_error):
+                    tasks.append((x, y))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+    cpdef list _full_frame(self, tuple pixels):
+
+        cdef:
+            list tasks
+            int nx, ny, x, y
+
+        tasks = []
+        nx, ny = pixels
+        for x in range(nx):
+            for y in range(ny):
+                tasks.append((x, y))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+
+cdef class MaskedSpectralAdaptiveSampler2D(FrameSampler2D):
+    """
+    A masked FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
+    level in each pixel's power value.
+
+    Pixels that have high noise levels will receive extra samples until the desired
+    noise threshold is achieve across the masked image.
+
+    :param SpectralPowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
+    :param np.ndarray mask: The image mask array.
+    :param int min_samples: Minimum number of pixel samples across the image before
+      turning on adaptive sampling (default=1000).
+    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
+      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
+      cutoff of 0.01 corresponds to 1% standard error.
+    :param str reduction_method: A method for obtaining spectral-average value of normalised
+      error of a pixel from spectral array of errors (default='percentile').
+       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+         average of the spectral errors,
+       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+         of the spectral errors excluding spectral bins with zero power,
+       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+         percentile of the spectral errors excluding spectral bins with zero power.
+    :param double percentile: If `reduction_method='percentile'`, defines the percentile of
+      statistical errors of spectral bins with non-zero power, which is used to calculate
+      normalised error of a pixel (default=100). If `percentile=x`, extra sampling will be aborted
+      if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
+    """
+
+    cdef:
+        SpectralPowerPipeline2D _pipeline
+        double _cutoff, _percentile
+        str _reduction_method
+        int _min_samples
+        np.ndarray _mask
+
+    def __init__(self, object pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0,
+                 str reduction_method='percentile', double percentile=100.):
+
+        self.pipeline = pipeline
+        self.mask = mask
+        self.min_samples = min_samples
+        self.cutoff = cutoff
+        self.reduction_method = reduction_method
+        self.percentile = percentile
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, (SpectralPowerPipeline2D, SpectralRadiancePipeline2D)):
+            raise TypeError('Sampler only compatible with SpectralPowerPipeLine2D or SpectralRadiancePipeline2D pipelines.')
+        self._pipeline = value
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, np.ndarray value):
+        if value.ndim != 2:
+            raise ValueError("Mask must be a 2D array")
+        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
+            raise TypeError("Mask must be an array of booleans or integers")
+        self._mask = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
+
+    @property
+    def reduction_method(self):
+        return self._reduction_method
+
+    @reduction_method.setter
+    def reduction_method(self, value):
+        if value not in {'weighted', 'mean', 'percentile'}:
+            raise ValueError("reduction_method must be 'weighted', 'mean' or 'percentile'")
+        self._reduction_method = value
+
+    @property
+    def percentile(self):
+        return self._percentile
+
+    @percentile.setter
+    def percentile(self, value):
+        if value < 0 or value > 100.:
+            raise ValueError("Percentiles must be in the range [0, 100]")
+        self._percentile = value
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef list generate_tasks(self, tuple pixels):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z, count
+            np.ndarray normalised, spectral_normalised
+            double[::1] spectral_normalised_mv
+            double[:, ::1] normalised_mv
+            double[:, :, ::1] error
+            double pixel_power
+            list tasks
+
+        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
+
+        frame = self.pipeline.frame
+        if frame is None:
+            # no frame data available, generate tasks for the full frame
+            return self._full_frame(pixels)
+
+        # sanity check
+        if pixels != (frame.nx, frame.ny):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
+
+        error = frame.errors()
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+
+        # calculated normalised standard error
+        if self.reduction_method == 'weighted':
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    pixel_power = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z]
+                            pixel_power += frame.mean_mv[x, y, z]
+                    if pixel_power:
+                        normalised_mv[x, y] /= pixel_power
+
+        elif self.reduction_method == 'mean':
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    count = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z] / frame.mean_mv[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] /= count
+        else:
+            spectral_normalised = np.zeros(frame.nz)
+            spectral_normalised_mv = spectral_normalised
+            for x in range(frame.nx):
+                for y in range(frame.ny):
+                    count = 0
+                    for z in range(frame.nz):
+                        if frame.mean_mv[x, y, z] > 0:
+                            spectral_normalised_mv[count] = error[x, y, z] / frame.mean_mv[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] = np.percentile(spectral_normalised[:count], self.percentile)
+
+        # build tasks
+        tasks = []
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if self.mask[x, y] and (frame.samples[x, y].min() < self.min_samples or normalised_mv[x, y] > self.cutoff):
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -274,7 +829,10 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     :param RGBPipeline2D pipeline: The specific RGB pipeline to use for feedback control.
     :param float fraction: The fraction of frame pixels to receive extra sampling
       (default=0.2).
-    :param float ratio:
+    :param float ratio: The maximum allowable ratio between the maximum and minimum number of
+      samples obtained for the pixels of the same observer (default=10).
+      The sampler will generate additional tasks for pixels with the least number of samples
+      in order to keep this ratio below a given value.
     :param int min_samples: Minimum number of pixel samples across the image before
       turning on adaptive sampling (default=1000).
     :param double cutoff: Noise threshold at which extra sampling will be aborted and
@@ -282,18 +840,67 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     """
 
     cdef:
-        RGBPipeline2D pipeline
-        double fraction, ratio, cutoff
-        int min_samples
+        RGBPipeline2D _pipeline
+        double _fraction, _ratio, _cutoff
+        int _min_samples
 
     def __init__(self, RGBPipeline2D pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0):
 
-        # todo: validation
         self.pipeline = pipeline
         self.fraction = fraction
         self.ratio = ratio
         self.min_samples = min_samples
         self.cutoff = cutoff
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, RGBPipeline2D):
+            raise TypeError('Sampler only compatible with RGBPipeline2D pipeline.')
+        self._pipeline = value
+
+    @property
+    def fraction(self):
+        return self._fraction
+
+    @fraction.setter
+    def fraction(self, value):
+        if value <= 0 or value > 1.:
+            raise ValueError("fraction must be in the range (0, 1]")
+        self._fraction = value
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        if value < 1.:
+            raise ValueError("ratio must be >= 1")
+        self._ratio = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -385,18 +992,59 @@ cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
     """
 
     cdef:
-        RGBPipeline2D pipeline
-        double fraction, ratio, cutoff
-        int min_samples
-        np.ndarray mask
+        RGBPipeline2D _pipeline
+        double _fraction, _cutoff
+        int _min_samples
+        np.ndarray _mask
 
     def __init__(self, RGBPipeline2D pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0):
 
-        # todo: validation
         self.pipeline = pipeline
         self.min_samples = min_samples
         self.cutoff = cutoff
         self.mask = mask
+
+    @property
+    def pipeline(self):
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, value):
+        if not isinstance(value, RGBPipeline2D):
+            raise TypeError('Sampler only compatible with RGBPipeline2D pipeline.')
+        self._pipeline = value
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, np.ndarray value):
+        if value.ndim != 2:
+            raise ValueError("Mask must be a 2D array")
+        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
+            raise TypeError("Mask must be an array of booleans or integers")
+        self._mask = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 1:
+            raise ValueError("min_samples must be >= 1")
+        self._min_samples = value
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value):
+        if value < 0 or value > 1.:
+            raise ValueError("cutoff must be in the range [0, 1]")
+        self._cutoff = value
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -405,13 +1053,16 @@ cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
 
         cdef:
             StatsArray3D frame
-            int x, y, c, min_samples, samples
+            int x, y, c, samples
             np.ndarray normalised
             double[:,:,::1] error
             double[:,::1] normalised_mv
             double percentile_error
             list tasks
             double[3] pixel_normalised
+
+        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
 
         frame = self.pipeline.xyz_frame
         if frame is None:
@@ -422,10 +1073,6 @@ cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
         if (pixels[0], pixels[1], 3) != frame.shape:
             raise ValueError('The number of pixels passed to the frame sampler are inconsistent with the pipeline frame size.')
 
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
-            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
-
-        min_samples = self.min_samples
         error = frame.errors()
         normalised = np.zeros((frame.nx, frame.ny))
         normalised_mv = normalised
@@ -446,7 +1093,7 @@ cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
             for y in range(frame.ny):
                 if self.mask[x, y]:
                     samples = min(frame.samples_mv[x, y, 0], frame.samples_mv[x, y, 1], frame.samples_mv[x, y, 2])
-                    if samples < min_samples or normalised_mv[x, y] > self.cutoff:
+                    if samples < self.min_samples or normalised_mv[x, y] > self.cutoff:
                         tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially

--- a/raysect/optical/observer/sampler2d.pyx
+++ b/raysect/optical/observer/sampler2d.pyx
@@ -65,7 +65,7 @@ cdef class FullFrameSampler2D(FrameSampler2D):
             self._mask = None
         else:
             if value.ndim != 2:
-                raise ValueError("Mask must be a 2D array")
+                raise ValueError("Mask must be a 2D array.")
             self._mask = value.astype(np.bool)
             self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
@@ -157,7 +157,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("Attribute 'fraction' must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -167,7 +167,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("Attribute 'ratio' must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -177,7 +177,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("Attribute 'min_samples' must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -187,7 +187,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("Attribute 'cutoff' must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @property
@@ -200,7 +200,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
             self._mask = None
         else:
             if value.ndim != 2:
-                raise ValueError("Mask must be a 2D array")
+                raise ValueError("Mask must be a 2D array.")
             self._mask = value.astype(np.bool)
             self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
@@ -393,7 +393,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("Attribute 'fraction' must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -403,7 +403,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("Attribute 'ratio' must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -413,7 +413,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("Attribute 'min_samples' must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -423,7 +423,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("Attribute 'cutoff' must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @property
@@ -433,7 +433,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @reduction_method.setter
     def reduction_method(self, value):
         if value not in {'weighted', 'mean', 'percentile', 'power_percentile'}:
-            raise ValueError("Attribute 'reduction_method' must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
+            raise ValueError("Attribute 'reduction_method' must be 'weighted', 'mean', 'percentile' or 'power_percentile'.")
         self._reduction_method = value
 
     @property
@@ -443,7 +443,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @percentile.setter
     def percentile(self, value):
         if value < 0 or value > 100.:
-            raise ValueError("Percentiles must be in the range [0, 100]")
+            raise ValueError("Percentiles must be in the range [0, 100].")
         self._percentile = value
 
     @property
@@ -456,7 +456,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
             self._mask = None
         else:
             if value.ndim != 2:
-                raise ValueError("Mask must be a 2D array")
+                raise ValueError("Mask must be a 2D array.")
             self._mask = value.astype(np.bool)
             self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
@@ -508,7 +508,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
 
         else:
             raise ValueError("Attribute 'reduction_method' has wrong value: %s. " % self._reduction_method +
-                             "Must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
+                             "Must be 'weighted', 'mean', 'percentile' or 'power_percentile'.")
 
         normalised_mv = normalised
 
@@ -747,7 +747,7 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("fraction must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1].")
         self._fraction = value
 
     @property
@@ -757,7 +757,7 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("ratio must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1.")
         self._ratio = value
 
     @property
@@ -767,7 +767,7 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("min_samples must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1.")
         self._min_samples = value
 
     @property
@@ -777,7 +777,7 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1].")
         self._cutoff = value
 
     @property
@@ -790,7 +790,7 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
             self._mask = None
         else:
             if value.ndim != 2:
-                raise ValueError("Mask must be a 2D array")
+                raise ValueError("Mask must be a 2D array.")
             self._mask = value.astype(np.bool)
             self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 

--- a/raysect/optical/observer/sampler2d.pyx
+++ b/raysect/optical/observer/sampler2d.pyx
@@ -27,49 +27,31 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
 import numpy as np
 from random import shuffle
 
 from raysect.optical.observer.base cimport FrameSampler2D
 from raysect.optical.observer.pipeline cimport RGBPipeline2D, RadiancePipeline2D, PowerPipeline2D, SpectralRadiancePipeline2D, SpectralPowerPipeline2D
-from raysect.core.math cimport StatsArray1D, StatsArray2D, StatsArray3D
-from timeit import default_timer as timer
+from raysect.core.math cimport StatsArray2D, StatsArray3D
 cimport numpy as np
 cimport cython
+ctypedef np.uint8_t uint8  # numpy boolean arrays are stored as 8-bit values
 
 
 cdef class FullFrameSampler2D(FrameSampler2D):
-    """ Evenly samples the full 2D frame. """
-
-    cpdef list generate_tasks(self, tuple pixels):
-
-        cdef:
-            list tasks
-            int nx, ny
-
-        tasks = []
-        nx, ny = pixels
-        for iy in range(ny):
-            for ix in range(nx):
-                tasks.append((ix, iy))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-
-cdef class MaskedFrameSampler2D(FrameSampler2D):
     """
-    Evenly samples the masked 2D frame.
+    Evenly samples the full 2D frame or its masked fragment.
 
-    :param np.ndarray mask: The image mask array.
+    :param np.ndarray mask: The image mask array (default=None). A 2D boolean array with
+      the same shape as the frame. The tasks are generated only for those pixels for which
+      the mask is True.
     """
-
     cdef:
         np.ndarray _mask
+        uint8[:, ::1] _mask_mv
 
-    def __init__(self, np.ndarray mask):
+    def __init__(self, np.ndarray mask=None):
 
         self.mask = mask
 
@@ -79,26 +61,35 @@ cdef class MaskedFrameSampler2D(FrameSampler2D):
 
     @mask.setter
     def mask(self, np.ndarray value):
-        if value.ndim != 2:
-            raise ValueError("Mask must be a 2D array")
-        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
-            raise TypeError("Mask must be an array of booleans or integers")
-        self._mask = value
+        if value is None:
+            self._mask = None
+        else:
+            if value.ndim != 2:
+                raise ValueError("Mask must be a 2D array")
+            self._mask = value.astype(np.bool)
+            self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
     cpdef list generate_tasks(self, tuple pixels):
 
         cdef:
             list tasks
             int nx, ny
 
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+        # The all-true mask is created during the first call of generate_tasks if no mask was provided
+        if self.mask is None:
+            self.mask = np.ones(pixels, dtype=np.bool)
+
+        if pixels != (self._mask.shape[0], self._mask.shape[1]):
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
 
         tasks = []
         nx, ny = pixels
         for iy in range(ny):
             for ix in range(nx):
-                if self.mask[ix, iy]:
+                if self._mask_mv[ix, iy]:
                     tasks.append((ix, iy))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -116,31 +107,38 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     noise threshold is achieve across the whole image.
 
     :param PowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
-    :param float fraction: The fraction of frame pixels to receive extra sampling
-      (default=0.2).
+    :param float fraction: The fraction of frame (or its masked fragment) pixels to receive
+      extra sampling (default=0.2).
     :param float ratio: The maximum allowable ratio between the maximum and minimum number of
       samples obtained for the pixels of the same observer (default=10).
       The sampler will generate additional tasks for pixels with the least number of samples
       in order to keep this ratio below a given value.
-    :param int min_samples: Minimum number of pixel samples across the image before
-      turning on adaptive sampling (default=1000).
+    :param int min_samples: Minimum number of pixel samples across the image
+      (or its masked fragment) before turning on adaptive sampling (default=1000).
     :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
       rendering will complete (default=0.0). The standard error is normalised to 1 so that a
       cutoff of 0.01 corresponds to 1% standard error.
+    :param np.ndarray mask: The image mask array (default=None). A 2D boolean array with
+      the same shape as the frame. The tasks are generated only for those pixels for which
+      the mask is True. If not provided, the all-true mask will be created during the first call
+      of generate_tasks().
     """
 
     cdef:
         PowerPipeline2D _pipeline
         double _fraction, _ratio, _cutoff
         int _min_samples
+        np.ndarray _mask
+        uint8[:, ::1] _mask_mv
 
-    def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0):
+    def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0, mask=None):
 
         self.pipeline = pipeline
         self.fraction = fraction
         self.ratio = ratio
         self.min_samples = min_samples
         self.cutoff = cutoff
+        self.mask = mask
 
     @property
     def pipeline(self):
@@ -159,7 +157,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("fraction must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1]")
         self._fraction = value
 
     @property
@@ -169,7 +167,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("ratio must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1")
         self._ratio = value
 
     @property
@@ -179,7 +177,7 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("min_samples must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1")
         self._min_samples = value
 
     @property
@@ -189,115 +187,8 @@ cdef class MonoAdaptiveSampler2D(FrameSampler2D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1]")
         self._cutoff = value
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    cpdef list generate_tasks(self, tuple pixels):
-
-        cdef:
-            StatsArray2D frame
-            int x, y, min_samples
-            np.ndarray normalised
-            double[:, ::1] error, normalised_mv
-            double percentile_error
-            list tasks
-
-        frame = self.pipeline.frame
-        if frame is None:
-            # no frame data available, generate tasks for the full frame
-            return self._full_frame(pixels)
-
-        # sanity check
-        if pixels != frame.shape:
-            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
-
-        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
-        error = frame.errors()
-        normalised = np.zeros((frame.nx, frame.ny))
-        normalised_mv = normalised
-
-        # calculated normalised standard error
-        for x in range(frame.nx):
-            for y in range(frame.ny):
-                if frame.mean_mv[x, y] <= 0:
-                    normalised_mv[x, y] = 0
-                else:
-                    normalised_mv[x, y] = error[x, y] / frame.mean_mv[x, y]
-
-        # locate error value corresponding to fraction of frame to process
-        percentile_error = np.percentile(normalised, (1 - self.fraction) * 100)
-
-        # build tasks
-        tasks = []
-        for x in range(frame.nx):
-            for y in range(frame.ny):
-                if frame.samples_mv[x, y] < min_samples or normalised_mv[x, y] > max(self.cutoff, percentile_error):
-                    tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-    cpdef list _full_frame(self, tuple pixels):
-
-        cdef:
-            list tasks
-            int nx, ny, x, y
-
-        tasks = []
-        nx, ny = pixels
-        for x in range(nx):
-            for y in range(ny):
-                tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-
-cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
-    """
-    A masked FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
-    level in each pixel's power value.
-
-    Pixels that have high noise levels will receive extra samples until the desired
-    noise threshold is achieve across the masked image.
-
-    :param PowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
-    :param np.ndarray mask: The image mask array.
-    :param int min_samples: Minimum number of pixel samples across the image before
-      turning on adaptive sampling (default=1000).
-    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
-      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
-      cutoff of 0.01 corresponds to 1% standard error.
-    """
-
-    cdef:
-        PowerPipeline2D _pipeline
-        double _cutoff
-        int _min_samples
-        np.ndarray _mask
-
-    def __init__(self, object pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0):
-
-        self.pipeline = pipeline
-        self.min_samples = min_samples
-        self.cutoff = cutoff
-        self.mask = mask
-
-    @property
-    def pipeline(self):
-        return self._pipeline
-
-    @pipeline.setter
-    def pipeline(self, value):
-        if not isinstance(value, (PowerPipeline2D, RadiancePipeline2D)):
-            raise TypeError('Sampler only compatible with PowerPipeLine2D or RadiancePipeline2D pipelines.')
-        self._pipeline = value
 
     @property
     def mask(self):
@@ -305,47 +196,37 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
 
     @mask.setter
     def mask(self, np.ndarray value):
-        if value.ndim != 2:
-            raise ValueError("Mask must be a 2D array")
-        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
-            raise TypeError("Mask must be an array of booleans or integers")
-        self._mask = value
-
-    @property
-    def min_samples(self):
-        return self._min_samples
-
-    @min_samples.setter
-    def min_samples(self, value):
-        if value < 1:
-            raise ValueError("min_samples must be >= 1")
-        self._min_samples = value
-
-    @property
-    def cutoff(self):
-        return self._cutoff
-
-    @cutoff.setter
-    def cutoff(self, value):
-        if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
-        self._cutoff = value
+        if value is None:
+            self._mask = None
+        else:
+            if value.ndim != 2:
+                raise ValueError("Mask must be a 2D array")
+            self._mask = value.astype(np.bool)
+            self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
     cpdef list generate_tasks(self, tuple pixels):
 
         cdef:
             StatsArray2D frame
-            int x, y
+            int x, y, min_samples
             np.ndarray normalised
-            double[:,::1] error, normalised_mv
+            double[:, ::1] error, mean, normalised_mv
+            int[:, ::1] samples
+            double percentile_error, cutoff
             list tasks
 
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+        # The all-true mask is created during the first call of generate_tasks if no mask was provided
+        if self.mask is None:
+            self.mask = np.ones(pixels, dtype=np.bool)
+
+        if pixels != (self._mask.shape[0], self._mask.shape[1]):
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
 
-        frame = self.pipeline.frame
+        frame = self._pipeline.frame
         if frame is None:
             # no frame data available, generate tasks for the full frame
             return self._full_frame(pixels)
@@ -354,23 +235,29 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
         if pixels != frame.shape:
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
 
+        min_samples = max(self._min_samples, <int>(frame.samples[self._mask].max() / self._ratio))
+
         error = frame.errors()
+        mean = frame.mean_mv  # does memoryview initialisation check before the loop
+        samples = frame.samples_mv  # same as above
         normalised = np.zeros((frame.nx, frame.ny))
         normalised_mv = normalised
 
         # calculated normalised standard error
         for x in range(frame.nx):
             for y in range(frame.ny):
-                if frame.mean_mv[x, y] <= 0:
-                    normalised_mv[x, y] = 0
-                else:
-                    normalised_mv[x, y] = error[x, y] / frame.mean_mv[x, y]
+                if self._mask_mv[x, y] and mean[x, y] > 0:
+                    normalised_mv[x, y] = error[x, y] / mean[x, y]
+
+        # locate error value corresponding to fraction of frame to process
+        percentile_error = np.percentile(normalised[self._mask], (1 - self._fraction) * 100)
+        cutoff = max(self._cutoff, percentile_error)
 
         # build tasks
         tasks = []
         for x in range(frame.nx):
             for y in range(frame.ny):
-                if self.mask[x, y] and (frame.samples_mv[x, y] < self.min_samples or normalised_mv[x, y] > self.cutoff):
+                if self._mask_mv[x, y] and (samples[x, y] < min_samples or normalised_mv[x, y] > cutoff):
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -378,23 +265,56 @@ cdef class MaskedMonoAdaptiveSampler2D(FrameSampler2D):
 
         return tasks
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
     cpdef list _full_frame(self, tuple pixels):
 
         cdef:
             list tasks
             int nx, ny, x, y
 
+        if self.mask is None:  # just in case if _full_frame() is called before generate_tasks()
+            self.mask = np.ones(pixels, dtype=np.bool)
+
         tasks = []
         nx, ny = pixels
         for x in range(nx):
             for y in range(ny):
-                if self.mask[x, y]:
+                if self._mask_mv[x, y]:
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
         shuffle(tasks)
 
         return tasks
+
+
+cdef class MaskedMonoAdaptiveSampler2D(MonoAdaptiveSampler2D):
+    """
+    A masked FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
+    level in each pixel's power value. Deprecated in version 0.7, instead use
+    MonoAdaptiveSampler2D with `mask` attribute.
+
+    Pixels that have high noise levels will receive extra samples until the desired
+    noise threshold is achieve across the masked image.
+
+    :param PowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
+    :param np.ndarray mask: The image mask array. A 2D boolean array with
+      the same shape as the frame. The tasks are generated only for those pixels for which
+      the mask is True.
+    :param int min_samples: Minimum number of pixel samples across the image before
+      turning on adaptive sampling (default=1000).
+    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
+      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
+      cutoff of 0.01 corresponds to 1% standard error.
+    """
+
+    def __init__(self, object pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0):
+
+        warnings.warn("MaskedMonoAdaptiveSampler2D is deprecated and will be removed in a future version. " +
+                      "Use MonoAdaptiveSampler2D with 'mask' attribute.", FutureWarning)
+        super().__init__(pipeline, fraction=1.0, ratio=100000.0, min_samples=min_samples, cutoff=cutoff, mask=mask)
 
 
 cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
@@ -406,29 +326,34 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     noise threshold is achieve across the whole image.
 
     :param SpectralPowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
-    :param float fraction: The fraction of frame pixels to receive extra sampling
-      (default=0.2).
+    :param float fraction: The fraction of frame (or its masked fragment) pixels to receive
+      extra sampling (default=0.2).
     :param float ratio: The maximum allowable ratio between the maximum and minimum number of
       samples obtained for the pixels of the same observer (default=10).
       The sampler will generate additional tasks for pixels with the least number of samples
       in order to keep this ratio below a given value.
-    :param int min_samples: Minimum number of pixel samples across the image before
-      turning on adaptive sampling (default=1000).
+    :param int min_samples: Minimum number of pixel samples across the image
+      (or its masked fragment) before turning on adaptive sampling (default=1000).
     :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
       rendering will complete (default=0.0). The standard error is normalised to 1 so that a
       cutoff of 0.01 corresponds to 1% standard error.
     :param str reduction_method: A method for obtaining spectral-average value of normalised
-      error of a pixel from spectral array of errors (default='percentile'). 
-       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
-         average of the spectral errors,
-       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
-         of the spectral errors excluding spectral bins with zero power,
-       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
-         percentile of the spectral errors excluding spectral bins with zero power.
-    :param double percentile: If `reduction_method='percentile'`, defines the percentile of
-      statistical errors of spectral bins with non-zero power, which is used to calculate
-      normalised error of a pixel (default=100). If `percentile=x`, extra sampling will be aborted
-      if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
+      error of a pixel from spectral array of errors (default='percentile').
+        - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+          average of the spectral errors,
+        - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+          of the spectral errors excluding spectral bins with zero power,
+        - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+          percentile of the spectral errors excluding spectral bins with zero power.
+        - `reduction_method='power_percentile'`: the error of a pixel is calculated as the highest
+          spectral error among a given percentage of spectral bins with the highest spectral power.
+    :param double percentile: Used only if `reduction_method='percentile'` or
+      `reduction_method='power_percentile'` (default=100).
+        - `reduction_method='percentile'`: If `percentile=x`, extra sampling will be aborted
+        if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
+        - `reduction_method='power_percentile'`: If `percentile=x`, extra sampling will be aborted
+        if `x`% of spectral bins with the highest spectral power have normalised error lower
+        than `cutoff`.
     """
 
     cdef:
@@ -436,9 +361,11 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
         double _fraction, _ratio, _cutoff, _percentile
         str _reduction_method
         int _min_samples
+        np.ndarray _mask
+        uint8[:, ::1] _mask_mv
 
     def __init__(self, object pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0,
-                 str reduction_method='percentile', double percentile=100.):
+                 str reduction_method='percentile', double percentile=100., np.ndarray mask=None):
 
         self.pipeline = pipeline
         self.fraction = fraction
@@ -447,6 +374,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
         self.cutoff = cutoff
         self.reduction_method = reduction_method
         self.percentile = percentile
+        self.mask = mask
 
     @property
     def pipeline(self):
@@ -455,7 +383,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @pipeline.setter
     def pipeline(self, value):
         if not isinstance(value, (SpectralPowerPipeline2D, SpectralRadiancePipeline2D)):
-            raise TypeError('Sampler only compatible with SpectralPowerPipeLine2D or SpectralRadiancePipeline2D pipelines.')
+            raise TypeError('Sampler only compatible with SpectralPowerPipeline2D or SpectralRadiancePipeline2D pipelines.')
         self._pipeline = value
 
     @property
@@ -465,7 +393,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @fraction.setter
     def fraction(self, value):
         if value <= 0 or value > 1.:
-            raise ValueError("fraction must be in the range (0, 1]")
+            raise ValueError("Attribute 'fraction' must be in the range (0, 1]")
         self._fraction = value
 
     @property
@@ -475,7 +403,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @ratio.setter
     def ratio(self, value):
         if value < 1.:
-            raise ValueError("ratio must be >= 1")
+            raise ValueError("Attribute 'ratio' must be >= 1")
         self._ratio = value
 
     @property
@@ -485,7 +413,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @min_samples.setter
     def min_samples(self, value):
         if value < 1:
-            raise ValueError("min_samples must be >= 1")
+            raise ValueError("Attribute 'min_samples' must be >= 1")
         self._min_samples = value
 
     @property
@@ -495,7 +423,7 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
     @cutoff.setter
     def cutoff(self, value):
         if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
+            raise ValueError("Attribute 'cutoff' must be in the range [0, 1]")
         self._cutoff = value
 
     @property
@@ -504,8 +432,8 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
 
     @reduction_method.setter
     def reduction_method(self, value):
-        if value not in {'weighted', 'mean', 'percentile'}:
-            raise ValueError("reduction_method must be 'weighted', 'mean' or 'percentile'")
+        if value not in {'weighted', 'mean', 'percentile', 'power_percentile'}:
+            raise ValueError("Attribute 'reduction_method' must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
         self._reduction_method = value
 
     @property
@@ -517,158 +445,6 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
         if value < 0 or value > 100.:
             raise ValueError("Percentiles must be in the range [0, 100]")
         self._percentile = value
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    cpdef list generate_tasks(self, tuple pixels):
-
-        cdef:
-            StatsArray3D frame
-            int x, y, z, count, min_samples
-            np.ndarray normalised, spectral_normalised
-            double[::1] spectral_normalised_mv
-            double[:, ::1] normalised_mv
-            double[:, :, ::1] error
-            double percentile_error, pixel_power
-            list tasks
-
-        frame = self.pipeline.frame
-        if frame is None:
-            # no frame data available, generate tasks for the full frame
-            return self._full_frame(pixels)
-
-        # sanity check
-        if pixels != (frame.nx, frame.ny):
-            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
-
-        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
-        error = frame.errors()
-        normalised = np.zeros((frame.nx, frame.ny))
-        normalised_mv = normalised
-
-        # calculated normalised standard error
-        if self.reduction_method == 'weighted':
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    pixel_power = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            normalised_mv[x, y] += error[x, y, z]
-                            pixel_power += frame.mean_mv[x, y, z]
-                    if pixel_power:
-                        normalised_mv[x, y] /= pixel_power
-
-        elif self.reduction_method == 'mean':
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    count = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            normalised_mv[x, y] += error[x, y, z] / frame.mean_mv[x, y, z]
-                            count += 1
-                    if count:
-                        normalised_mv[x, y] /= count
-        else:
-            spectral_normalised = np.zeros(frame.nz)
-            spectral_normalised_mv = spectral_normalised
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    count = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            spectral_normalised_mv[count] = error[x, y, z] / frame.mean_mv[x, y, z]
-                            count += 1
-                    if count:
-                        normalised_mv[x, y] = np.percentile(spectral_normalised[:count], self.percentile)
-
-        # locate error value corresponding to fraction of frame to process
-        percentile_error = np.percentile(normalised, (1 - self.fraction) * 100)
-
-        # build tasks
-        tasks = []
-        for x in range(frame.nx):
-            for y in range(frame.ny):
-                if frame.samples[x, y].min() < min_samples or normalised_mv[x, y] > max(self.cutoff, percentile_error):
-                    tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-    cpdef list _full_frame(self, tuple pixels):
-
-        cdef:
-            list tasks
-            int nx, ny, x, y
-
-        tasks = []
-        nx, ny = pixels
-        for x in range(nx):
-            for y in range(ny):
-                tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-
-cdef class MaskedSpectralAdaptiveSampler2D(FrameSampler2D):
-    """
-    A masked FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
-    level in each pixel's power value.
-
-    Pixels that have high noise levels will receive extra samples until the desired
-    noise threshold is achieve across the masked image.
-
-    :param SpectralPowerPipeline2D pipeline: The specific power pipeline to use for feedback control.
-    :param np.ndarray mask: The image mask array.
-    :param int min_samples: Minimum number of pixel samples across the image before
-      turning on adaptive sampling (default=1000).
-    :param double cutoff: Normalised noise threshold at which extra sampling will be aborted and
-      rendering will complete (default=0.0). The standard error is normalised to 1 so that a
-      cutoff of 0.01 corresponds to 1% standard error.
-    :param str reduction_method: A method for obtaining spectral-average value of normalised
-      error of a pixel from spectral array of errors (default='percentile').
-       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
-         average of the spectral errors,
-       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
-         of the spectral errors excluding spectral bins with zero power,
-       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
-         percentile of the spectral errors excluding spectral bins with zero power.
-    :param double percentile: If `reduction_method='percentile'`, defines the percentile of
-      statistical errors of spectral bins with non-zero power, which is used to calculate
-      normalised error of a pixel (default=100). If `percentile=x`, extra sampling will be aborted
-      if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
-    """
-
-    cdef:
-        SpectralPowerPipeline2D _pipeline
-        double _cutoff, _percentile
-        str _reduction_method
-        int _min_samples
-        np.ndarray _mask
-
-    def __init__(self, object pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0,
-                 str reduction_method='percentile', double percentile=100.):
-
-        self.pipeline = pipeline
-        self.mask = mask
-        self.min_samples = min_samples
-        self.cutoff = cutoff
-        self.reduction_method = reduction_method
-        self.percentile = percentile
-
-    @property
-    def pipeline(self):
-        return self._pipeline
-
-    @pipeline.setter
-    def pipeline(self, value):
-        if not isinstance(value, (SpectralPowerPipeline2D, SpectralRadiancePipeline2D)):
-            raise TypeError('Sampler only compatible with SpectralPowerPipeLine2D or SpectralRadiancePipeline2D pipelines.')
-        self._pipeline = value
 
     @property
     def mask(self):
@@ -676,70 +452,37 @@ cdef class MaskedSpectralAdaptiveSampler2D(FrameSampler2D):
 
     @mask.setter
     def mask(self, np.ndarray value):
-        if value.ndim != 2:
-            raise ValueError("Mask must be a 2D array")
-        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
-            raise TypeError("Mask must be an array of booleans or integers")
-        self._mask = value
-
-    @property
-    def min_samples(self):
-        return self._min_samples
-
-    @min_samples.setter
-    def min_samples(self, value):
-        if value < 1:
-            raise ValueError("min_samples must be >= 1")
-        self._min_samples = value
-
-    @property
-    def cutoff(self):
-        return self._cutoff
-
-    @cutoff.setter
-    def cutoff(self, value):
-        if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
-        self._cutoff = value
-
-    @property
-    def reduction_method(self):
-        return self._reduction_method
-
-    @reduction_method.setter
-    def reduction_method(self, value):
-        if value not in {'weighted', 'mean', 'percentile'}:
-            raise ValueError("reduction_method must be 'weighted', 'mean' or 'percentile'")
-        self._reduction_method = value
-
-    @property
-    def percentile(self):
-        return self._percentile
-
-    @percentile.setter
-    def percentile(self, value):
-        if value < 0 or value > 100.:
-            raise ValueError("Percentiles must be in the range [0, 100]")
-        self._percentile = value
+        if value is None:
+            self._mask = None
+        else:
+            if value.ndim != 2:
+                raise ValueError("Mask must be a 2D array")
+            self._mask = value.astype(np.bool)
+            self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
     cpdef list generate_tasks(self, tuple pixels):
 
         cdef:
             StatsArray3D frame
-            int x, y, z, count
-            np.ndarray normalised, spectral_normalised
-            double[::1] spectral_normalised_mv
+            int x, y, min_samples
+            np.ndarray normalised
             double[:, ::1] normalised_mv
-            double[:, :, ::1] error
-            double pixel_power
+            int[:, ::1] frame_min_samples
+            double percentile_error, cutoff
             list tasks
 
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
+        # The all-true mask is created during the first call of generate_tasks if no mask was provided
+        if self.mask is None:
+            self.mask = np.ones(pixels, dtype=np.bool)
+
+        if pixels != (self._mask.shape[0], self._mask.shape[1]):
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
 
-        frame = self.pipeline.frame
+        frame = self._pipeline.frame
         if frame is None:
             # no frame data available, generate tasks for the full frame
             return self._full_frame(pixels)
@@ -748,50 +491,37 @@ cdef class MaskedSpectralAdaptiveSampler2D(FrameSampler2D):
         if pixels != (frame.nx, frame.ny):
             raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the pipeline frame size.')
 
-        error = frame.errors()
-        normalised = np.zeros((frame.nx, frame.ny))
-        normalised_mv = normalised
+        min_samples = max(self._min_samples, <int>(frame.samples.max(2)[self._mask].max() / self._ratio))
 
         # calculated normalised standard error
-        if self.reduction_method == 'weighted':
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    pixel_power = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            normalised_mv[x, y] += error[x, y, z]
-                            pixel_power += frame.mean_mv[x, y, z]
-                    if pixel_power:
-                        normalised_mv[x, y] /= pixel_power
+        if self._reduction_method == 'weighted':
+            normalised = self._reduce_weighted()
 
-        elif self.reduction_method == 'mean':
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    count = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            normalised_mv[x, y] += error[x, y, z] / frame.mean_mv[x, y, z]
-                            count += 1
-                    if count:
-                        normalised_mv[x, y] /= count
+        elif self._reduction_method == 'mean':
+            normalised = self._reduce_mean()
+
+        elif self._reduction_method == 'percentile':
+            normalised = self._reduce_percentile()
+
+        elif self._reduction_method == 'power_percentile':
+            normalised = self._reduce_power_percentile()
+
         else:
-            spectral_normalised = np.zeros(frame.nz)
-            spectral_normalised_mv = spectral_normalised
-            for x in range(frame.nx):
-                for y in range(frame.ny):
-                    count = 0
-                    for z in range(frame.nz):
-                        if frame.mean_mv[x, y, z] > 0:
-                            spectral_normalised_mv[count] = error[x, y, z] / frame.mean_mv[x, y, z]
-                            count += 1
-                    if count:
-                        normalised_mv[x, y] = np.percentile(spectral_normalised[:count], self.percentile)
+            raise ValueError("Attribute 'reduction_method' has wrong value: %s. " % self._reduction_method +
+                             "Must be 'weighted', 'mean', 'percentile' or 'power_percentile'")
+
+        normalised_mv = normalised
+
+        # locate error value corresponding to fraction of frame to process
+        percentile_error = np.percentile(normalised[self._mask], (1 - self._fraction) * 100)
+        cutoff = max(self._cutoff, percentile_error)
 
         # build tasks
         tasks = []
+        frame_min_samples = frame.samples.min(2)
         for x in range(frame.nx):
             for y in range(frame.ny):
-                if self.mask[x, y] and (frame.samples[x, y].min() < self.min_samples or normalised_mv[x, y] > self.cutoff):
+                if self._mask_mv[x, y] and (frame_min_samples[x, y] < min_samples or normalised_mv[x, y] > cutoff):
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -799,17 +529,158 @@ cdef class MaskedSpectralAdaptiveSampler2D(FrameSampler2D):
 
         return tasks
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    cdef np.ndarray _reduce_weighted(self):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z
+            np.ndarray normalised
+            double[:, :, ::1] error, mean
+            double[:, ::1] normalised_mv
+            double pixel_power
+
+        frame = self._pipeline.frame
+        error = frame.errors()
+        mean = frame.mean_mv
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if self._mask_mv[x, y]:
+                    pixel_power = 0
+                    for z in range(frame.nz):
+                        if mean[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z]
+                            pixel_power += mean[x, y, z]
+                    if pixel_power:
+                        normalised_mv[x, y] /= pixel_power
+
+        return normalised
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    cdef np.ndarray _reduce_mean(self):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z, count
+            np.ndarray normalised
+            double[:, :, ::1] error, mean
+            double[:, ::1] normalised_mv
+
+        frame = self._pipeline.frame
+        error = frame.errors()
+        mean = frame.mean_mv
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if self._mask_mv[x, y]:
+                    count = 0
+                    for z in range(frame.nz):
+                        if mean[x, y, z] > 0:
+                            normalised_mv[x, y] += error[x, y, z] / mean[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] /= count
+
+        return normalised
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    cdef np.ndarray _reduce_percentile(self):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z, count
+            np.ndarray spectral_normalised, normalised
+            double[:, :, ::1] error, mean
+            double[:, ::1] normalised_mv
+            double[:] spectral_normalised_mv
+
+        frame = self._pipeline.frame
+        error = frame.errors()
+        mean = frame.mean_mv
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+        spectral_normalised = np.zeros(frame.nz)
+        spectral_normalised_mv = spectral_normalised
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if self._mask_mv[x, y]:
+                    count = 0
+                    for z in range(frame.nz):
+                        if mean[x, y, z] > 0:
+                            spectral_normalised_mv[count] = error[x, y, z] / mean[x, y, z]
+                            count += 1
+                    if count:
+                        normalised_mv[x, y] = np.percentile(spectral_normalised[:count], self._percentile)
+
+        return normalised
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    cdef np.ndarray _reduce_power_percentile(self):
+
+        cdef:
+            StatsArray3D frame
+            int x, y, z, count
+            np.ndarray normalised, spectral_power
+            double[:, :, ::1] error, mean
+            double[:, ::1] normalised_mv
+            double[:] spectral_power_mv
+            double power_threshold
+
+        frame = self._pipeline.frame
+        error = frame.errors()
+        mean = frame.mean_mv
+        normalised = np.zeros((frame.nx, frame.ny))
+        normalised_mv = normalised
+        spectral_power = np.zeros(frame.nz)
+        spectral_power_mv = spectral_power
+        for x in range(frame.nx):
+            for y in range(frame.ny):
+                if self._mask_mv[x, y]:
+                    count = 0
+                    for z in range(frame.nz):
+                        if mean[x, y, z] > 0:
+                            spectral_power_mv[count] = mean[x, y, z]
+                            count += 1
+                    if count:
+                        power_threshold = np.percentile(spectral_power[:count], (100. - self._percentile))
+                        for z in range(frame.nz):
+                            if mean[x, y, z] >= power_threshold:
+                                normalised_mv[x, y] = max(normalised_mv[x, y], error[x, y, z] / mean[x, y, z])
+
+        return normalised
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
     cpdef list _full_frame(self, tuple pixels):
 
         cdef:
             list tasks
             int nx, ny, x, y
 
+        if self.mask is None:  # just in case if _full_frame() is called before generate_tasks()
+            self.mask = np.ones(pixels, dtype=np.bool)
+
         tasks = []
         nx, ny = pixels
         for x in range(nx):
             for y in range(ny):
-                if self.mask[x, y]:
+                if self._mask_mv[x, y]:
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -827,30 +698,37 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
     noise threshold is achieve across the whole image.
 
     :param RGBPipeline2D pipeline: The specific RGB pipeline to use for feedback control.
-    :param float fraction: The fraction of frame pixels to receive extra sampling
-      (default=0.2).
+    :param float fraction: The fraction of frame (or its masked fragment) pixels to receive
+      extra sampling (default=0.2).
     :param float ratio: The maximum allowable ratio between the maximum and minimum number of
       samples obtained for the pixels of the same observer (default=10).
       The sampler will generate additional tasks for pixels with the least number of samples
       in order to keep this ratio below a given value.
-    :param int min_samples: Minimum number of pixel samples across the image before
-      turning on adaptive sampling (default=1000).
+    :param int min_samples: Minimum number of pixel samples across the image
+      (or its masked fragment) before turning on adaptive sampling (default=1000).
     :param double cutoff: Noise threshold at which extra sampling will be aborted and
       rendering will complete (default=0.0).
+    :param np.ndarray mask: The image mask array (default=None). A 2D boolean array with
+      the same shape as the frame. The tasks are generated only for those pixels for which
+      the mask is True. If not provided, the all-true mask will be created during the first call
+      of generate_tasks().
     """
 
     cdef:
         RGBPipeline2D _pipeline
         double _fraction, _ratio, _cutoff
         int _min_samples
+        np.ndarray _mask
+        uint8[:, ::1] _mask_mv
 
-    def __init__(self, RGBPipeline2D pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0):
+    def __init__(self, RGBPipeline2D pipeline, double fraction=0.2, double ratio=10.0, int min_samples=1000, double cutoff=0.0, np.ndarray mask=None):
 
         self.pipeline = pipeline
         self.fraction = fraction
         self.ratio = ratio
         self.min_samples = min_samples
         self.cutoff = cutoff
+        self.mask = mask
 
     @property
     def pipeline(self):
@@ -902,22 +780,45 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
             raise ValueError("cutoff must be in the range [0, 1]")
         self._cutoff = value
 
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, np.ndarray value):
+        if value is None:
+            self._mask = None
+        else:
+            if value.ndim != 2:
+                raise ValueError("Mask must be a 2D array")
+            self._mask = value.astype(np.bool)
+            self._mask_mv = np.frombuffer(self._mask, dtype=np.uint8).reshape(self.mask.shape)
+
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
+    @cython.initializedcheck(False)
     cpdef list generate_tasks(self, tuple pixels):
 
         cdef:
             StatsArray3D frame
-            int x, y, c, min_samples, samples
+            int x, y, c, min_samples, min_pixel_samples
             np.ndarray normalised
-            double[:,:,::1] error
-            double[:,::1] normalised_mv
-            double percentile_error
+            double[:, :, ::1] error, mean
+            double[:, ::1] normalised_mv
+            int[:, :, ::1] samples
+            double percentile_error, cutoff
             list tasks
             double[3] pixel_normalised
 
-        frame = self.pipeline.xyz_frame
+        # The all-true mask is created during the first call of generate_tasks if no mask was provided
+        if self.mask is None:
+            self.mask = np.ones(pixels, dtype=np.bool)
+
+        if pixels != (self._mask.shape[0], self._mask.shape[1]):
+            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
+
+        frame = self._pipeline.xyz_frame
         if frame is None:
             # no frame data available, generate tasks for the full frame
             return self._full_frame(pixels)
@@ -926,30 +827,57 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
         if (pixels[0], pixels[1], 3) != frame.shape:
             raise ValueError('The number of pixels passed to the frame sampler are inconsistent with the pipeline frame size.')
 
-        min_samples = max(self.min_samples, <int>(frame.samples.max() / self.ratio))
+        min_samples = max(self._min_samples, <int>(frame.samples[self._mask].max() / self._ratio))
         error = frame.errors()
+        mean = frame.mean_mv  # does memoryview initialisation check before the loop
+        samples = frame.samples_mv  # same as above
         normalised = np.zeros((frame.nx, frame.ny))
         normalised_mv = normalised
 
         # calculated normalised standard error
         for x in range(frame.nx):
             for y in range(frame.ny):
-                for c in range(3):
-                    if frame.mean_mv[x, y, c] <= 0:
-                        pixel_normalised[c] = 0
-                    else:
-                        pixel_normalised[c] = error[x, y, c] / frame.mean_mv[x, y, c]
-                normalised_mv[x, y] = max(pixel_normalised[0], pixel_normalised[1], pixel_normalised[2])
+                if self._mask_mv[x, y]:
+                    for c in range(3):
+                        if mean[x, y, c] > 0:
+                            pixel_normalised[c] = error[x, y, c] / mean[x, y, c]
+                    normalised_mv[x, y] = max(pixel_normalised[0], pixel_normalised[1], pixel_normalised[2])
 
         # locate error value corresponding to fraction of frame to process
-        percentile_error = np.percentile(normalised, (1 - self.fraction) * 100)
+        percentile_error = np.percentile(normalised[self._mask], (1 - self._fraction) * 100)
+        cutoff = max(self._cutoff, percentile_error)
 
         # build tasks
         tasks = []
         for x in range(frame.nx):
             for y in range(frame.ny):
-                samples = min(frame.samples_mv[x, y, 0], frame.samples_mv[x, y, 1], frame.samples_mv[x, y, 2])
-                if samples < min_samples or normalised_mv[x, y] > max(self.cutoff, percentile_error):
+                if self._mask_mv[x, y]:
+                    min_pixel_samples = min(samples[x, y, 0], samples[x, y, 1], samples[x, y, 2])
+                    if min_pixel_samples < min_samples or normalised_mv[x, y] > cutoff:
+                        tasks.append((x, y))
+
+        # perform tasks in random order so that image is assembled randomly rather than sequentially
+        shuffle(tasks)
+
+        return tasks
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
+    cpdef list _full_frame(self, tuple pixels):
+
+        cdef:
+            list tasks
+            int nx, ny, x, y
+
+        if self.mask is None:  # just in case if _full_frame() is called before generate_tasks()
+            self.mask = np.ones(pixels, dtype=np.bool)
+
+        tasks = []
+        nx, ny = pixels
+        for x in range(nx):
+            for y in range(ny):
+                if self._mask_mv[x, y]:
                     tasks.append((x, y))
 
         # perform tasks in random order so that image is assembled randomly rather than sequentially
@@ -957,28 +885,12 @@ cdef class RGBAdaptiveSampler2D(FrameSampler2D):
 
         return tasks
 
-    cpdef list _full_frame(self, tuple pixels):
 
-        cdef:
-            list tasks
-            int nx, ny, x, y
-
-        tasks = []
-        nx, ny = pixels
-        for x in range(nx):
-            for y in range(ny):
-                tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-
-cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
+cdef class MaskedRGBAdaptiveSampler2D(RGBAdaptiveSampler2D):
     """
     A masked FrameSampler that dynamically adjusts a camera's pixel samples based on the noise
-    level in each RGB pixel value.
+    level in each RGB pixel value. Deprecated in version 0.7, instead use MonoAdaptiveSampler2D
+    with `mask` attribute.
 
     Pixels that have high noise levels will receive extra samples until the desired
     noise threshold is achieve across the whole image.
@@ -991,130 +903,8 @@ cdef class MaskedRGBAdaptiveSampler2D(FrameSampler2D):
       rendering will complete (default=0.0).
     """
 
-    cdef:
-        RGBPipeline2D _pipeline
-        double _fraction, _cutoff
-        int _min_samples
-        np.ndarray _mask
-
     def __init__(self, RGBPipeline2D pipeline, np.ndarray mask, int min_samples=1000, double cutoff=0.0):
 
-        self.pipeline = pipeline
-        self.min_samples = min_samples
-        self.cutoff = cutoff
-        self.mask = mask
-
-    @property
-    def pipeline(self):
-        return self._pipeline
-
-    @pipeline.setter
-    def pipeline(self, value):
-        if not isinstance(value, RGBPipeline2D):
-            raise TypeError('Sampler only compatible with RGBPipeline2D pipeline.')
-        self._pipeline = value
-
-    @property
-    def mask(self):
-        return self._mask
-
-    @mask.setter
-    def mask(self, np.ndarray value):
-        if value.ndim != 2:
-            raise ValueError("Mask must be a 2D array")
-        if value.dtype not in (np.int, np.int32, np.int64, np.bool):
-            raise TypeError("Mask must be an array of booleans or integers")
-        self._mask = value
-
-    @property
-    def min_samples(self):
-        return self._min_samples
-
-    @min_samples.setter
-    def min_samples(self, value):
-        if value < 1:
-            raise ValueError("min_samples must be >= 1")
-        self._min_samples = value
-
-    @property
-    def cutoff(self):
-        return self._cutoff
-
-    @cutoff.setter
-    def cutoff(self, value):
-        if value < 0 or value > 1.:
-            raise ValueError("cutoff must be in the range [0, 1]")
-        self._cutoff = value
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    @cython.cdivision(True)
-    cpdef list generate_tasks(self, tuple pixels):
-
-        cdef:
-            StatsArray3D frame
-            int x, y, c, samples
-            np.ndarray normalised
-            double[:,:,::1] error
-            double[:,::1] normalised_mv
-            double percentile_error
-            list tasks
-            double[3] pixel_normalised
-
-        if pixels != (self.mask.shape[0], self.mask.shape[1]):
-            raise ValueError('The pixel geometry passed to the frame sampler is inconsistent with the mask frame size.')
-
-        frame = self.pipeline.xyz_frame
-        if frame is None:
-            # no frame data available, generate tasks for the full frame
-            return self._full_frame(pixels)
-
-        # sanity check
-        if (pixels[0], pixels[1], 3) != frame.shape:
-            raise ValueError('The number of pixels passed to the frame sampler are inconsistent with the pipeline frame size.')
-
-        error = frame.errors()
-        normalised = np.zeros((frame.nx, frame.ny))
-        normalised_mv = normalised
-
-        # calculated normalised standard error
-        for x in range(frame.nx):
-            for y in range(frame.ny):
-                for c in range(3):
-                    if frame.mean_mv[x, y, c] <= 0:
-                        pixel_normalised[c] = 0
-                    else:
-                        pixel_normalised[c] = error[x, y, c] / frame.mean_mv[x, y, c]
-                normalised_mv[x, y] = max(pixel_normalised[0], pixel_normalised[1], pixel_normalised[2])
-
-        # build tasks
-        tasks = []
-        for x in range(frame.nx):
-            for y in range(frame.ny):
-                if self.mask[x, y]:
-                    samples = min(frame.samples_mv[x, y, 0], frame.samples_mv[x, y, 1], frame.samples_mv[x, y, 2])
-                    if samples < self.min_samples or normalised_mv[x, y] > self.cutoff:
-                        tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
-
-    cpdef list _full_frame(self, tuple pixels):
-
-        cdef:
-            list tasks
-            int nx, ny, x, y
-
-        tasks = []
-        nx, ny = pixels
-        for x in range(nx):
-            for y in range(ny):
-                if self.mask[x, y]:
-                    tasks.append((x, y))
-
-        # perform tasks in random order so that image is assembled randomly rather than sequentially
-        shuffle(tasks)
-
-        return tasks
+        warnings.warn("MaskedRGBAdaptiveSampler2D is deprecated and will be removed in a future version. " +
+                      "Use RGBAdaptiveSampler2D with 'mask' attribute.", FutureWarning)
+        super().__init__(pipeline, fraction=1.0, ratio=100000.0, min_samples=min_samples, cutoff=cutoff, mask=mask)

--- a/raysect/optical/observer/sampler2d.pyx
+++ b/raysect/optical/observer/sampler2d.pyx
@@ -339,21 +339,21 @@ cdef class SpectralAdaptiveSampler2D(FrameSampler2D):
       cutoff of 0.01 corresponds to 1% standard error.
     :param str reduction_method: A method for obtaining spectral-average value of normalised
       error of a pixel from spectral array of errors (default='percentile').
-        - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
-          average of the spectral errors,
-        - `reduction_method='mean'`: the error of a pixel is calculated as a mean
-          of the spectral errors excluding spectral bins with zero power,
-        - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
-          percentile of the spectral errors excluding spectral bins with zero power.
-        - `reduction_method='power_percentile'`: the error of a pixel is calculated as the highest
-          spectral error among a given percentage of spectral bins with the highest spectral power.
+       - `reduction_method='weighted'`: the error of a pixel is calculated as power-weighted
+         average of the spectral errors,
+       - `reduction_method='mean'`: the error of a pixel is calculated as a mean
+         of the spectral errors excluding spectral bins with zero power,
+       - `reduction_method='percentile'`: the error of a pixel is calculated as a user-defined
+         percentile of the spectral errors excluding spectral bins with zero power.
+       - `reduction_method='power_percentile'`: the error of a pixel is calculated as the highest
+         spectral error among a given percentage of spectral bins with the highest spectral power.
     :param double percentile: Used only if `reduction_method='percentile'` or
       `reduction_method='power_percentile'` (default=100).
-        - `reduction_method='percentile'`: If `percentile=x`, extra sampling will be aborted
-        if `x`% of spectral bins of each pixel have normalised error lower than `cutoff`.
-        - `reduction_method='power_percentile'`: If `percentile=x`, extra sampling will be aborted
-        if `x`% of spectral bins with the highest spectral power have normalised error lower
-        than `cutoff`.
+       - `reduction_method='percentile'`: If `percentile=x`, extra sampling will be aborted
+         if x% of spectral bins of each pixel have normalised errors lower than `cutoff`.
+       - `reduction_method='power_percentile'`: If `percentile=x`, extra sampling will be aborted
+         if x% of spectral bins with the highest spectral power all have normalised errors lower
+         than `cutoff`.
     """
 
     cdef:


### PR DESCRIPTION
This adds the following new samplers:
- `MaskedFrameSampler2D`,
- `SpectralAdaptiveSampler1D`,
- `SpectralAdaptiveSampler2D`,
- `MaskedSpectralAdaptiveSampler2D`.

Also, parameter validation is added for all adaptive samplers (I hope this doesn't break anything).

`SpectralAdaptiveSampler2D` is useful when calculating in a single run multiple filtered camera images with different filters. It has three options for how to reduce the spectral array of normalized errors to a single value for a pixel. I'll be happy to add more options if needed.

There are also two small changes in documentation:
- description of `ratio` parameter of adaptive samplers is added,
- all previously missing pipelines and samplers are added to API reference.
