### PR TITLE
Fast emitters and integrators for regular grids

### DIFF
--- a/demos/materials/regular_grid_emitters/0_regular_grid_emitter.py
+++ b/demos/materials/regular_grid_emitters/0_regular_grid_emitter.py
@@ -1,0 +1,224 @@
+import numpy as np
+from scipy.sparse import csc_matrix, csr_matrix
+from matplotlib import pyplot as plt
+
+from raysect.optical import InterpolatedSF, Ray
+from raysect.optical.material import RegularGridEmitter
+
+"""
+Demonstration of RegularGridEmitter functionality
+-------------------------------------------------
+
+This file demonstrates basic functions of RegularGridEmitter, the emitter material created
+to speed up volume integration through the emission profiles defined on a regular 3D spatial grids.
+"""
+
+
+""" Part 1: Contineous spectrum. """
+print('Part 1: Contineous spectrum.\n')
+
+
+# Let's define a simple 3x3x3 gird.
+grid_shape = (3, 3, 3)  # grid shape
+grid_steps = (1., 1., 1.)  # grid steps (in meters)
+
+
+# Let's define the spectral range and the emission law.
+min_wavelength = 375.
+max_wavelength = 740.
+spectral_points = 365
+wavelengths = np.linspace(min_wavelength, max_wavelength, spectral_points)
+xwl = (wavelengths - min_wavelength) / (max_wavelength - min_wavelength) * 3 * np.pi
+cos2_law = np.cos(xwl)**2
+sin2_law = np.sin(xwl)**2
+
+
+# Assume that only 9 out of 27 grid cells emit (8 corners and a central cell).
+emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], spectral_points))
+emission[::2, ::2, ::2, :] = cos2_law[None, None, None, :]  # W / (m^3 str nm)
+emission[1, 1, 1, :] = 2. * sin2_law  # W / (m^3 str nm)
+
+
+# Let's define the emitting material.
+material = RegularGridEmitter(grid_shape, grid_steps, emission, wavelengths)
+# The emission profile is stored as a compressed sparse column matrix (scipy.sparse.csc_matrix).
+# It can be passed as a csc_matrix (or any other scipy sparce matrix).
+nvoxel = grid_shape[0] * grid_shape[1] * grid_shape[2]
+emission_csc = csc_matrix(emission.reshape(nvoxel, spectral_points))
+material = RegularGridEmitter(grid_shape, grid_steps, emission_csc, wavelengths)
+# By default, the spectral emission profile is extrpolated outside the specified spectral range.
+# If emission profile must be zero outside the spectral range, 'extrapolate' parameter must be set to False.
+material.extrapolate = False
+
+
+# Built-in function integrate(wl0, wl1) allows to integrate the emission profile in a spectral range
+# between wl0 and wl1.
+wl0 = 500.
+wl1 = 650.
+wl_integral = material.integrate(wl0, wl1)
+# wl_integral is a one-column csc_matrix.
+# We can compare the results with the results of InterpolatedSF.integrate()
+isf_corner = InterpolatedSF(wavelengths, cos2_law)
+print('RegularGridEmitter integral (corner): %g' % wl_integral[0, 0])
+print('InterpolatedSF integral (corner): %g' % isf_corner.integrate(wl0, wl1))
+print()
+# To get the flat index of the central cell we can use voxel_index() function.
+ivoxel = material.voxel_index(1, 1, 1)
+isf_center = InterpolatedSF(wavelengths, 2. * sin2_law)
+print('RegularGridEmitter integral (center): %g' % wl_integral[ivoxel, 0])
+print('InterpolatedSF integral (center): %g' % isf_center.integrate(wl0, wl1))
+print()
+
+
+# Similar to SpectralFunction, RegularGridEmitter resamples spectral emission profile
+# for the specific spectral properties of the ray: ray.min_wavelength, ray.max_wavelength, ray.bins.
+# And similar to SpectralFunction, the resampled emission profile is cached.
+# Both the special integrators and the built-in emission_function(), which is used only with general
+# integrators, check if the cache is valid for the ray spectral properties before performing calculations
+# and rebuild the cache if necessary.
+# However, it is possible to build the cache manually with cache_build() function.
+# Cache validity can be checked with cache_valid() function.
+ray = Ray(min_wavelength=400., max_wavelength=700., bins=60)
+print('Is the cache valid? %s' % material.cache_valid(ray.min_wavelength, ray.max_wavelength, ray.bins))
+material.cache_build(ray.min_wavelength, ray.max_wavelength, ray.bins)
+print('And now? %s' % material.cache_valid(ray.min_wavelength, ray.max_wavelength, ray.bins))
+print()
+# Note that calling the cache_build() function again with the same arguments will do nothing because
+# it checks for cache validity first. However, it is possible to forcefully rebuild the cache
+# by specifying a forced argument.
+material.cache_build(ray.min_wavelength, ray.max_wavelength, ray.bins, forced=True)
+# While the cache_build() is called automatically, it may be useful to call it in advance in the case of
+# multi-process rendering in the scenarios when ray spectral properties do not change during the rendering
+# (e.g., when dispersive rendering is turned off).
+# When cache_build() is called after the camera.observe(), each process will create its own cache, but when
+# cache_build() is called before camera.observe(), all processes will use the same cache while it's valid.
+# Thus when working with large spatial grids, a lot of memory can be saved.
+
+
+# Let's compare sampled emission with the original values.
+sample_wavelengths, sample_delta = np.linspace(ray.min_wavelength, ray.max_wavelength, ray.bins + 1, retstep=True)
+sample_wavelengths = sample_wavelengths[:-1] + 0.5 * sample_delta
+samples_corner = np.zeros(sample_wavelengths.size)
+material.add_emission_to_array(samples_corner, 0, 0, 0, 1.0)
+samples_center = np.zeros(sample_wavelengths.size)
+material.add_emission_to_array(samples_center, 1, 1, 1, 1.0)
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+ax.plot(wavelengths, cos2_law, label='Original (corner)')
+ax.plot(wavelengths, 2. * sin2_law, label='Original (center)')
+ax.plot(sample_wavelengths, samples_corner, ls='', marker='o', label='Sampled (corner)')
+ax.plot(sample_wavelengths, samples_center, ls='', marker='o', label='Sampled (center)')
+ax.set_xlabel('wavelength, nm')
+ax.legend(loc=1, ncol=2, frameon=False, bbox_to_anchor=(1.0, 1.15))
+fig.savefig('demo_0_regular_grid_emitter.png')
+
+
+# Note that sampling conserves the wavelength integral.
+print('Integral (%g nm - %g nm): %g' % (ray.min_wavelength, ray.max_wavelength,
+                                        material.integrate(ray.min_wavelength, ray.max_wavelength)[0, 0]))
+print('Sampled integral (%g nm - %g nm): %g' % (ray.min_wavelength, ray.max_wavelength,
+                                                samples_corner.sum() * sample_delta))
+print()
+
+
+""" Part 2: Discrete spectrum. """
+print('Part 2: Discrete spectrum.\n')
+
+
+# Some materials (e.g. atoms) emit only at certain wavelengths.
+# Assume that each cell from the 3x3x3 grid emit only at its own unique wavelength (spectral line).
+wavelengths = np.linspace(min_wavelength, max_wavelength, nvoxel)
+emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], nvoxel))
+for i in range(grid_shape[0]):
+    for j in range(grid_shape[1]):
+        for k in range(grid_shape[2]):
+            emission[i, j, k, i * grid_shape[0] * grid_shape[1] + j * grid_shape[1] + k] = 1.   # W / (m^3 str)
+# In the case of discrete emitters, the emission must be provided in W/(m^3 str) (not in W/(m^3 str nm)).
+# A special option 'contineous' must be set to False at initialisation.
+material = RegularGridEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=False)
+
+
+# When integrating over wavelngth, this emitter acts similar to the delta-function.
+# The integral between wl0 and wl1 is just a sum of the emissions at all spectral lines between wl0 and wl1,
+# or zero if there are no spectral lines between wl0 and wl1.
+total_integral = material.integrate(min_wavelength - 0.1, max_wavelength + 0.1).toarray().reshape(grid_shape)
+print('Total integral for all cells:\n', total_integral)
+partial_integral = material.integrate(500, 620).toarray().reshape(grid_shape)
+print('Integral (500 nm - 600 nm) for all cells:\n', partial_integral)
+print()
+
+
+# Let's create a sample for the discrete emitter
+ray = Ray(min_wavelength=400., max_wavelength=700., bins=150)
+material.cache_build(ray.min_wavelength, ray.max_wavelength, ray.bins)
+# The cache contains the emission converted from W/(m^3 str) to W/(m^3 str nm).
+# Let's check this.
+samples = np.zeros(ray.bins)
+material.add_emission_to_array(samples, 1, 1, 1, 1.0)
+ivoxel = material.voxel_index(1, 1, 1)
+print('Emission at %g nm: %g W/(m^3 str)' % (wavelengths[ivoxel], emission[1, 1, 1, ivoxel]))
+# All elements of 'samples' array except one are zeros.
+bin_index = np.argmax(samples)
+samples_delta = (ray.max_wavelength - ray.min_wavelength) / ray.bins
+bin_min_wl = ray.min_wavelength + bin_index * samples_delta
+print('Emission in %g nm - %g nm: %g W/(m^3 str nm)' % (bin_min_wl, bin_min_wl + samples_delta, samples[bin_index]))
+print('Spectral step: %g nm' % samples_delta)
+print()
+# Like in the case of contineous spectrum, sampling conserves the wavelength integral.
+
+
+""" Part 3: Memory saving. """
+print('Part 3: Memory saving.\n')
+
+
+# Working with large 3D spatial grids and high spectral resolution consumes a lot of memory.
+# RegularGridEmitter stores both the original emission profile and the cache in sparse matrices.
+# If the emission lower than a certain threshold can be neglected, explicitly zeroing the values lower
+# than this threshold before passing the emission to RegularGridEmitter, allow to save some memory.
+
+# If the emission spectrum has some regions where the material does not emit, the emission should be
+# explicitly zeroed at the borders of these regions. Otherwise, the spectrum will be interpolated
+# between these regions during the sampling and the cache will be filled with negligable in terms of
+# physics but non-zero values. This will not only increase memory consumption but also the computing time.
+
+# As shown above, the emission can be passed to RegularGridEmitter as a scipy csc_matrix. This saves memory.
+# Building the cache manually before camera.observe() call when possible also saves memory in case of
+# multi-process rendering.
+
+
+# It is possible to store the cache in float32 instead of float64 with a 'cache_32bit' option. Do this, if
+# memory consumption is too large for your machine.
+# Setting this option when the cache is already built in 64-bit, deletes the current cache.
+print('Is cache 32-bit? %s' % material.cache_32bit)
+print('Is cache empty? %s' % material.cache_empty())
+material.cache_32bit = True
+print('Is cache empty now? %s' % material.cache_empty())
+material.cache_build(ray.min_wavelength, ray.max_wavelength, ray.bins)
+print('Is cache 32-bit now? %s' % material.cache_32bit)
+print()
+# Note that all computations are perfromed with double precision, so converting from float32 to
+# float64 on the fly will consume some time.
+
+
+# If none of the above solutions work and memory consumption is still too large, there is an option to
+# initialise RegularGridEmitter with a dummy emission array and then provide the pre-calculated cache.
+# Of course, this solution will work only if ray spectral properties do not change during the rendering.
+wavelengths, delta = np.linspace(ray.min_wavelength, ray.max_wavelength, ray.bins + 1, retstep=True)
+wavelengths = wavelengths[:-1] + 0.5 * delta
+xwl = (wavelengths - ray.min_wavelength) / (ray.max_wavelength - ray.min_wavelength) * 3 * np.pi
+cos2_law = np.cos(xwl)**2
+sin2_law = np.sin(xwl)**2
+emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], ray.bins))
+emission[::2, ::2, ::2, :] = cos2_law[None, None, None, :]  # W / (m^3 str nm)
+emission[1, 1, 1, :] = 2. * sin2_law  # W / (m^3 str nm)
+# Cache is stored as a csr_matrix and must be provided in that form.
+cache = csr_matrix(emission.reshape(nvoxel, ray.bins), dtype=np.float32)
+material = RegularGridEmitter(grid_shape, grid_steps, csr_matrix((nvoxel, 2)),
+                              np.array([ray.min_wavelength, ray.max_wavelength]))  # initialising with a dummy emission array
+material.cache_override(cache, ray.min_wavelength, ray.max_wavelength)  # overriding the cache
+print('Is cache valid? %s' % material.cache_valid(ray.min_wavelength, ray.max_wavelength, ray.bins))
+print('Is cache 32-bit? %s' % material.cache_32bit)  # we provided the cache in float32
+print()
+
+plt.show()

--- a/demos/materials/regular_grid_emitters/0_regular_grid_emitter.py
+++ b/demos/materials/regular_grid_emitters/0_regular_grid_emitter.py
@@ -14,8 +14,8 @@ to speed up volume integration through the emission profiles defined on a regula
 """
 
 
-""" Part 1: Contineous spectrum. """
-print('Part 1: Contineous spectrum.\n')
+""" Part 1: continuous spectrum. """
+print('Part 1: continuous spectrum.\n')
 
 
 # Let's define a simple 3x3x3 gird.
@@ -135,8 +135,8 @@ for i in range(grid_shape[0]):
         for k in range(grid_shape[2]):
             emission[i, j, k, i * grid_shape[0] * grid_shape[1] + j * grid_shape[1] + k] = 1.   # W / (m^3 str)
 # In the case of discrete emitters, the emission must be provided in W/(m^3 str) (not in W/(m^3 str nm)).
-# A special option 'contineous' must be set to False at initialisation.
-material = RegularGridEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=False)
+# A special option 'continuous' must be set to False at initialisation.
+material = RegularGridEmitter(grid_shape, grid_steps, emission, wavelengths, continuous=False)
 
 
 # When integrating over wavelngth, this emitter acts similar to the delta-function.
@@ -165,7 +165,7 @@ bin_min_wl = ray.min_wavelength + bin_index * samples_delta
 print('Emission in %g nm - %g nm: %g W/(m^3 str nm)' % (bin_min_wl, bin_min_wl + samples_delta, samples[bin_index]))
 print('Spectral step: %g nm' % samples_delta)
 print()
-# Like in the case of contineous spectrum, sampling conserves the wavelength integral.
+# Like in the case of continuous spectrum, sampling conserves the wavelength integral.
 
 
 """ Part 3: Memory saving. """

--- a/demos/materials/regular_grid_emitters/1_cartesian_regular_grid.py
+++ b/demos/materials/regular_grid_emitters/1_cartesian_regular_grid.py
@@ -1,0 +1,92 @@
+
+import os
+import time
+from matplotlib.pyplot import *
+import numpy as np
+
+from raysect.optical import World, translate, rotate, Point3D
+from raysect.optical.library import RoughTitanium
+from raysect.optical.observer import PinholeCamera, RGBPipeline2D, RGBAdaptiveSampler2D
+from raysect.primitive import Box
+from raysect.optical.material import RegularGridBox
+
+"""
+RegularGridBox Demonstration
+----------------------------
+
+This file demonstrates how to use RegularGridBox to effectively integrate through
+the emission profiles defined on a regular grid.
+
+This demonstration uses exactly the same emission profile as
+demos/material/volume.py demonstration. It is recomended to run the
+volume.py demo first for better understanding.
+
+Notice tenfold speedup compared to the Raysect's volume.py demo achieved by
+pre-calculating the emission profile on a regular grid.
+
+Even higher speedup can be achieved for smaller integration steps. Reducing the
+integration step to 0.01 in both demos (along with doubling the grid resolution
+in this demo) results in 50x speedup.
+
+"""
+
+# grid parameters
+xmin = ymin = -1.
+xmax = ymax = 1.
+zmin = -0.25
+zmax = 0.25
+x, dx = np.linspace(xmin, xmax, 101, retstep=True)
+y, dy = np.linspace(ymin, ymax, 101, retstep=True)
+integration_step = 0.05
+# x, dx = np.linspace(xmin, xmax, 201, retstep=True)
+# y, dy = np.linspace(ymin, ymax, 201, retstep=True)
+# integration_step = 0.01
+x = x[:-1] + 0.5 * dx  # moving to the grid cell centers
+y = y[:-1] + 0.5 * dy
+
+# spectral emission profile
+min_wavelength = 375.
+max_wavelength = 740.
+spectral_points = 50
+wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, spectral_points, retstep=True)
+wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+wvl_range = min_wavelength - max_wavelength
+shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+radius = np.sqrt((x * x)[:, None] + (y * y)[None, :])
+emission = np.cos(shift[None, None, None, :] * radius[:, :, None, None])**4
+
+# scene
+world = World()
+emitter = RegularGridBox(emission, wavelengths, xmax=xmax - xmin, ymax=ymax - ymin, zmax=zmax - zmin,
+                         step=integration_step, parent=world)
+emitter.transform = translate(0, 1., 0) * rotate(30, 0, 0) * translate(xmin, ymin, zmin)
+floor = Box(Point3D(-100, -0.1, -100), Point3D(100, 0, 100), world, material=RoughTitanium(0.1))
+
+# camera
+rgb_pipeline = RGBPipeline2D(display_update_time=5)
+sampler = RGBAdaptiveSampler2D(rgb_pipeline, min_samples=100, fraction=0.2)
+camera = PinholeCamera((512, 512), parent=world, transform=translate(0, 4, -3.5) * rotate(0, -45, 0), pipelines=[rgb_pipeline], frame_sampler=sampler)
+camera.min_wavelength = min_wavelength
+camera.max_wavelength = max_wavelength
+camera.spectral_bins = 15
+camera.spectral_rays = 1
+camera.pixel_samples = 200
+
+# Here, ray spectral properties do not change during the rendering,
+# so we build the cache before the first camera.observe() call to reduce memory consumption
+# in multiprocess rendering.
+emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength, camera.spectral_bins)
+# start ray tracing
+os.nice(15)
+ion()
+timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+for p in range(1, 1000):
+    print("Rendering pass {}...".format(p))
+    camera.observe()
+    rgb_pipeline.save("demo_regular_grid_box_{}_pass_{}.png".format(timestamp, p))
+    print()
+
+# display final result
+ioff()
+rgb_pipeline.display()
+show()

--- a/demos/materials/regular_grid_emitters/1_cartesian_regular_grid.py
+++ b/demos/materials/regular_grid_emitters/1_cartesian_regular_grid.py
@@ -83,7 +83,7 @@ timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
 for p in range(1, 1000):
     print("Rendering pass {}...".format(p))
     camera.observe()
-    rgb_pipeline.save("demo_regular_grid_box_{}_pass_{}.png".format(timestamp, p))
+    rgb_pipeline.save("demo_1_cartesian_regular_grid_{}_pass_{}.png".format(timestamp, p))
     print()
 
 # display final result

--- a/demos/materials/regular_grid_emitters/2_cylindrical_regular_grid.py
+++ b/demos/materials/regular_grid_emitters/2_cylindrical_regular_grid.py
@@ -1,0 +1,84 @@
+
+import os
+import time
+from matplotlib.pyplot import *
+import numpy as np
+
+from raysect.optical import World, translate, rotate, Point3D
+from raysect.optical.library import RoughTitanium
+from raysect.optical.observer import PinholeCamera, RGBPipeline2D, RGBAdaptiveSampler2D
+from raysect.primitive import Box
+from raysect.optical.material import CylindricalRegularEmitter
+
+"""
+CylindricalRegularEmitter Demonstration
+---------------------------------------
+
+This file demonstrates how to use CylindricalRegularEmitter material to effectively
+integrate through the emission profiles defined on a regular grid.
+
+The same emission profile as in RegularGridBox demo is defined here in cylindrical
+coordinates. Due to rectangular shape of the emission profile, we cannot use
+RegularGridCylinder, so here we assign CylindricalRegularEmitter material to a Box.
+"""
+
+# grid parameters
+xmin = ymin = -1.
+xmax = ymax = 1.
+zmin = -0.25
+zmax = 0.25
+rmin = 0
+rmax = np.sqrt(2.)
+r, dr = np.linspace(rmin, rmax, 201, retstep=True)
+integration_step = 0.05
+r = r[:-1] + 0.5 * dr  # moving to the grid cell centers
+grid_shape = (200, 1, 1)
+grid_steps = (dr, 360, zmax - zmin)  # axisymmetric emission
+
+# spectral emission profile
+min_wavelength = 375.
+max_wavelength = 740.
+spectral_points = 50
+wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, spectral_points, retstep=True)
+wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+wvl_range = min_wavelength - max_wavelength
+shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+emission = np.cos(shift[None, None, None, :] * r[:, None, None, None])**4
+
+# scene
+world = World()
+material = CylindricalRegularEmitter(grid_shape, grid_steps, emission, wavelengths, rmin=rmin)
+material.integrator.step = integration_step
+# we need to align the internal coordinate system of the box with the material grid
+emitter = Box(lower=Point3D(xmin, ymin, 0), upper=Point3D(xmax, ymax, zmax - zmin), parent=world,
+              material=material, transform=translate(0, 1, 0) * rotate(30, 0, 0) * translate(0, 0, zmin))
+floor = Box(Point3D(-100, -0.1, -100), Point3D(100, 0, 100), world, material=RoughTitanium(0.1))
+
+# camera
+rgb_pipeline = RGBPipeline2D(display_update_time=5)
+sampler = RGBAdaptiveSampler2D(rgb_pipeline, min_samples=100, fraction=0.2)
+camera = PinholeCamera((512, 512), parent=world, transform=translate(0, 4, -3.5) * rotate(0, -45, 0), pipelines=[rgb_pipeline], frame_sampler=sampler)
+camera.min_wavelength = min_wavelength
+camera.max_wavelength = max_wavelength
+camera.spectral_bins = 15
+camera.spectral_rays = 1
+camera.pixel_samples = 200
+
+# Here, ray spectral properties do not change during the rendering,
+# so we build the cache before the first camera.observe() call to reduce memory consumption
+# in multiprocess rendering.
+emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength, camera.spectral_bins)
+# start ray tracing
+os.nice(15)
+ion()
+timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+for p in range(1, 1000):
+    print("Rendering pass {}...".format(p))
+    camera.observe()
+    rgb_pipeline.save("demo_regular_grid_cylinder_{}_pass_{}.png".format(timestamp, p))
+    print()
+
+# display final result
+ioff()
+rgb_pipeline.display()
+show()

--- a/demos/materials/regular_grid_emitters/2_cylindrical_regular_grid.py
+++ b/demos/materials/regular_grid_emitters/2_cylindrical_regular_grid.py
@@ -32,7 +32,7 @@ rmax = np.sqrt(2.)
 r, dr = np.linspace(rmin, rmax, 201, retstep=True)
 integration_step = 0.05
 r = r[:-1] + 0.5 * dr  # moving to the grid cell centers
-grid_shape = (200, 1, 1)
+grid_shape = (r.size, 1, 1)
 grid_steps = (dr, 360, zmax - zmin)  # axisymmetric emission
 
 # spectral emission profile
@@ -75,7 +75,7 @@ timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
 for p in range(1, 1000):
     print("Rendering pass {}...".format(p))
     camera.observe()
-    rgb_pipeline.save("demo_regular_grid_cylinder_{}_pass_{}.png".format(timestamp, p))
+    rgb_pipeline.save("demo_2_cylindrical)regular_grid_{}_pass_{}.png".format(timestamp, p))
     print()
 
 # display final result

--- a/demos/materials/regular_grid_emitters/3_discrete_spectrum.py
+++ b/demos/materials/regular_grid_emitters/3_discrete_spectrum.py
@@ -39,7 +39,7 @@ for i, wl in enumerate(wavelengths):
 # scene
 world = World()
 emitter = RegularGridCylinder(emission, wavelengths, radius_outer=rmax, height=zmax - zmin, radius_inner=rmin,
-                              step=integration_step, contineous=False, parent=world)  # discrete emitter
+                              step=integration_step, continuous=False, parent=world)  # discrete emitter
 emitter.transform = translate(0, rmax, 0) * rotate(30, 0, 0) * translate(0, 0, zmin)
 floor = Box(Point3D(-100, -0.1, -100), Point3D(100, 0, 100), world, material=RoughTitanium(0.1))
 

--- a/demos/materials/regular_grid_emitters/3_discrete_spectrum.py
+++ b/demos/materials/regular_grid_emitters/3_discrete_spectrum.py
@@ -1,0 +1,73 @@
+
+import os
+import time
+from matplotlib.pyplot import *
+import numpy as np
+
+from raysect.optical import World, translate, rotate, Point3D
+from raysect.optical.library import RoughTitanium
+from raysect.optical.observer import PinholeCamera, RGBPipeline2D, RGBAdaptiveSampler2D
+from raysect.primitive import Box
+from raysect.optical.material import RegularGridCylinder
+
+"""
+Demonstration of discrete emitter
+---------------------------------
+
+This file demonstrates how to define the regular grid emitter with discrete spectrum.
+"""
+
+# axisymmetric cylindrical grid
+zmin = -0.25
+zmax = 0.25
+rmin = 0
+rmax = np.sqrt(2.)
+r, dr = np.linspace(rmin, rmax, 401, retstep=True)
+integration_step = 0.02
+r = r[:-1] + 0.5 * dr  # moving to the grid cell centers
+
+# spectral emission profile
+wavelengths = np.array([410.2, 434.0, 486.1, 656.5])  # Balmer series in visible spectrum
+min_wavelength = 380.
+max_wavelength = 690.
+x = min_wavelength + (r - rmin) / (rmax - rmin) * (max_wavelength - min_wavelength)
+emission = np.zeros((r.size, 1, 1, 4))
+sigma = 10.
+for i, wl in enumerate(wavelengths):
+    emission[:, 0, 0, i] = np.exp(-0.5 * ((x - wl) / sigma) ** 2) / (sigma * np.sqrt(2. * np.pi))  # emission must be in W / (m^3 str)
+
+# scene
+world = World()
+emitter = RegularGridCylinder(emission, wavelengths, radius_outer=rmax, height=zmax - zmin, radius_inner=rmin,
+                              step=integration_step, contineous=False, parent=world)  # discrete emitter
+emitter.transform = translate(0, rmax, 0) * rotate(30, 0, 0) * translate(0, 0, zmin)
+floor = Box(Point3D(-100, -0.1, -100), Point3D(100, 0, 100), world, material=RoughTitanium(0.1))
+
+# camera
+rgb_pipeline = RGBPipeline2D(display_update_time=5)
+sampler = RGBAdaptiveSampler2D(rgb_pipeline, min_samples=100, fraction=0.2)
+camera = PinholeCamera((512, 512), parent=world, transform=translate(0, 5, -4.5) * rotate(0, -45, 0), pipelines=[rgb_pipeline], frame_sampler=sampler)
+camera.min_wavelength = min_wavelength
+camera.max_wavelength = max_wavelength
+camera.spectral_bins = 15
+camera.spectral_rays = 1
+camera.pixel_samples = 200
+
+# Here, ray spectral properties do not change during the rendering,
+# so we build the cache before the first camera.observe() call to reduce memory consumption
+# in multiprocess rendering.
+emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength, camera.spectral_bins)
+# start ray tracing
+os.nice(15)
+ion()
+timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+for p in range(1, 1000):
+    print("Rendering pass {}...".format(p))
+    camera.observe()
+    rgb_pipeline.save("demo_3_discrete_spectrum_{}_pass_{}.png".format(timestamp, p))
+    print()
+
+# display final result
+ioff()
+rgb_pipeline.display()
+show()

--- a/raysect/optical/material/emitter/__init__.pxd
+++ b/raysect/optical/material/emitter/__init__.pxd
@@ -33,4 +33,6 @@ from raysect.optical.material.emitter.homogeneous cimport HomogeneousVolumeEmitt
 from raysect.optical.material.emitter.inhomogeneous cimport InhomogeneousVolumeEmitter, VolumeIntegrator, NumericalIntegrator
 from raysect.optical.material.emitter.checkerboard cimport Checkerboard
 from raysect.optical.material.emitter.anisotropic cimport AnisotropicSurfaceEmitter
+from raysect.optical.material.emitter.regular_grid_emitters cimport RegularGridEmitter, CartesianRegularEmitter, CylindricalRegularEmitter
+from raysect.optical.material.emitter.regular_grid_emitters cimport RegularGridIntegrator, CartesianRegularIntegrator, CylindricalRegularIntegrator
 

--- a/raysect/optical/material/emitter/regular_grid_emitters.pxd
+++ b/raysect/optical/material/emitter/regular_grid_emitters.pxd
@@ -58,7 +58,7 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
 
     cdef:
         readonly long nvoxel
-        readonly bint contineous
+        readonly bint continuous
         readonly bint cache_32bit_indices
         readonly ndarray wavelengths
         readonly object emission

--- a/raysect/optical/material/emitter/regular_grid_emitters.pxd
+++ b/raysect/optical/material/emitter/regular_grid_emitters.pxd
@@ -57,7 +57,7 @@ cdef class CartesianRegularIntegrator(RegularGridIntegrator):
 cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
 
     cdef:
-        readonly int nvoxel
+        readonly long nvoxel
         readonly bint contineous
         readonly bint cache_32bit_indices
         readonly ndarray wavelengths
@@ -81,9 +81,9 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
         const long[::1] cache_indptr_64_mv
         const long[::1] cache_indices_64_mv
 
-    cdef int get_voxel_index(self, int i, int j, int k) nogil
+    cdef long get_voxel_index(self, int i, int j, int k) nogil
 
-    cpdef int voxel_index(self, int i, int j, int k)
+    cpdef long voxel_index(self, int i, int j, int k)
 
     cdef void _cache_init(self)
 

--- a/raysect/optical/material/emitter/regular_grid_emitters.pxd
+++ b/raysect/optical/material/emitter/regular_grid_emitters.pxd
@@ -1,0 +1,135 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from numpy cimport ndarray
+from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
+from raysect.optical.material.emitter.inhomogeneous cimport VolumeIntegrator, InhomogeneousVolumeEmitter
+cimport cython
+
+
+cdef class RegularGridIntegrator(VolumeIntegrator):
+    
+    cdef:
+        double _step
+        int _min_samples
+
+cdef class CylindricalRegularIntegrator(RegularGridIntegrator):
+
+    cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
+                             InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
+                             AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+
+cdef class CartesianRegularIntegrator(RegularGridIntegrator):
+
+    cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
+                             InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
+                             AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+
+
+cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
+
+    cdef:
+        readonly int nvoxel
+        readonly bint contineous
+        readonly bint cache_32bit_indices
+        readonly ndarray wavelengths
+        readonly object emission
+
+        int[3] _grid_shape
+        double[3] _grid_steps
+        bint _extrapolate
+        bint _cache_32bit
+        double _cache_min_wvl
+        double _cache_max_wvl
+        int _cache_num_samp
+        long _cache_data_size
+        object _cache
+        double[::1] _wavelengths_mv
+
+        const float[::1] cache_data_32_mv
+        const double[::1] cache_data_64_mv
+        const int[::1] cache_indptr_32_mv
+        const int[::1] cache_indices_32_mv
+        const long[::1] cache_indptr_64_mv
+        const long[::1] cache_indices_64_mv
+
+    cdef int get_voxel_index(self, int i, int j, int k) nogil
+
+    cpdef int voxel_index(self, int i, int j, int k)
+
+    cdef void _cache_init(self)
+
+    cpdef bint cache_valid(self, double min_wavelength, double max_wavelength, int bins)
+
+    cpdef bint cache_empty(self)
+
+    cpdef void cache_override(self, object cache, double min_wavelength, double max_wavelength)
+
+    cpdef void cache_build(self, double min_wavelength, double max_wavelength, int bins, bint forced=*)
+
+    cpdef object integrate(self, double min_wavelength, double max_wavelength)
+
+    cdef void add_emission_to_mv(self, double[::1] samples_mv, int i, int j, int k, double ray_path) nogil
+
+    cpdef void add_emission_to_array(self, ndarray samples, int i, int j, int k, double ray_path)
+
+
+cdef class CylindricalRegularEmitter(RegularGridEmitter):
+
+    cdef:
+        readonly double rmin
+        readonly double dr
+        readonly double dphi
+        readonly double dz
+        readonly double period
+        readonly int nr
+        readonly int nphi
+        readonly int nz
+
+    cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
+                                     World world, Ray ray, Primitive primitive,
+                                     AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+
+
+cdef class CartesianRegularEmitter(RegularGridEmitter):
+
+    cdef:
+        readonly double dx
+        readonly double dy
+        readonly double dz
+        readonly int nx
+        readonly int ny
+        readonly int nz
+
+    cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
+                                     World world, Ray ray, Primitive primitive,
+                                     AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+    

--- a/raysect/optical/material/emitter/regular_grid_emitters.pyx
+++ b/raysect/optical/material/emitter/regular_grid_emitters.pyx
@@ -1,0 +1,1060 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2017, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+The following emitters and integrators are used in Regular Grid Volumes.
+They allow fast integration along the ray's trajectory as they use pre-calculated
+values of spectral emissivity on a regular grid.
+Note that these emitters support other integrators as well, however high performance
+with other integrators is not guaranteed.
+
+Performance tips:
+
+  * Current version of `RegularGridEmitter` does not supports grids with more than
+    2147483647 grid cells or the caches with more than 2147483647 non-zero data points
+    (> 16 GB of data). If this an issue, try to divide the grid into several parts and
+    distribure it between multiple emitters.
+
+  * If dispesive rendering is off (`camera.spectral_rays = 1`) and spectral properties of
+    rays do not change during rendering, consider calling:
+
+    .. code-block:: pycon
+        >>> emitter.build_cache(camera.min_wavelength, camera.max_wavelength,
+                                camera.spectral_bins)
+
+    before the first call of `camera.observe()`. This will save a lot of memory in case of
+    multi-process rendering, as well as some time between the calls of `camera.observe()`.
+
+  * In case of insufficient memory, one can initialise the emitter with a dummy emission
+    array and then populate the cache directly with a pre-calculated `csr_matrix`.
+
+    .. code-block:: pycon
+        >>> grid_size = grid_shape[0] * grid_shape[1] * grid_shape[2]
+        >>> wavelengths = np.ones(1)
+        >>> emission = csc_matrix((grid_size, 1))
+        >>> emitter = CartesianRegularEmitter(grid_shape, grid_steps, emission,
+                                              wavelengths)
+        >>> emitter.cache_override(cache, camera.min_wavelength, camera.max_wavelength)
+
+    Note that `cache.shape` must be equal to `(grid_size, camera.spectral_bins)`.
+    This solution will work only if dispesive rendering is off (`camera.spectral_rays = 1`)
+    and spectral properties of rays do not change during rendering.
+
+  * If the emission spectrum has some regions where the material does not emit, the emission should be
+    explicitly zeroed at the borders of these regions. Otherwise, the spectrum will be interpolated
+    between these regions during the sampling and the cache will be filled with negligable in terms of
+    physics but non-zero values. This will not only increase memory consumption but also the computing time.
+"""
+
+import numpy as np
+from scipy.sparse import csr_matrix, csc_matrix
+from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
+from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
+from libc.math cimport sqrt, atan2, M_PI as pi
+from .regular_grid_utility cimport integrate_contineous, integrate_delta_function
+cimport numpy as np
+cimport cython
+
+
+cdef class RegularGridIntegrator(VolumeIntegrator):
+    """
+    Basic class for regular grid integrators.
+
+    :param float step: Integration step (in meters), defaults to `step=0.001`.
+    :param int min_samples: The minimum number of samples to use over integration range,
+        defaults to `min_samples=2`.
+
+    :ivar float step: Integration step.
+    :ivar int min_samples: The minimum number of samples to use over integration range.
+    """
+
+    def __init__(self, double step=0.001, int min_samples=2):
+        self.step = step
+        self.min_samples = min_samples
+
+    @property
+    def step(self):
+        return self._step
+
+    @step.setter
+    def step(self, value):
+        if value <= 0:
+            raise ValueError("Numerical integration step size can not be less than or equal to zero.")
+        self._step = value
+
+    @property
+    def min_samples(self):
+        return self._min_samples
+
+    @min_samples.setter
+    def min_samples(self, value):
+        if value < 2:
+            raise ValueError("At least two samples are required to perform the numerical integration.")
+        self._min_samples = value
+
+
+cdef class CylindricalRegularIntegrator(RegularGridIntegrator):
+    """
+    Integrates the spectral emissivity defined on a regular grid
+    in cylindrical coordinate system: :math:`(R, \phi, Z)` along the ray's trajectory.
+    This integrator must be used with the `CylindricalRegularEmitter` material class. 
+    It is assumed that the emitter is periodic in :math:`\phi` direction with a period
+    equal to `material.period`.
+    This integrator does not perform interpolation, so the spectral emissivity at
+    any spatial point along the ray's trajectory is equal to that of the grid cell
+    where this point is located.
+    """
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
+                             InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
+                             AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world):
+
+        cdef:
+            Point3D start, end
+            Vector3D direction
+            int it, ir, iphi, iz, ir_current, iphi_current, iz_current, n
+            double length, t, dt, x, y, z, r, phi, ray_path
+            CylindricalRegularEmitter emitter
+
+        if not isinstance(material, CylindricalRegularEmitter):
+            raise TypeError('Only CylindricalRegularEmitter material is supported by CylindricalRegularIntegrator.')
+
+        emitter = material
+        # Building the cache if required
+        emitter.cache_build(ray.get_min_wavelength(), ray.get_max_wavelength(), ray.get_bins())
+
+        if emitter.cache_empty():  # emitter does not emit at this wavelength range
+            return spectrum
+
+        # Determining direction of integration and effective integration step
+        start = start_point.transform(world_to_primitive)  # start point in local coordinates
+        end = end_point.transform(world_to_primitive)  # end point in local coordinates
+        direction = start.vector_to(end)  # direction of integration
+        length = direction.get_length()  # integration length
+        if length < 0.1 * self._step:  # return if ray's path is too short
+            return spectrum
+
+        direction = direction.normalise()  # normalized direction
+        n = max(self._min_samples, <int>(length / self._step))  # number of points along ray's trajectory
+        dt = length / n  # integration step
+
+        # Starting integration
+        ir_current = 0
+        iphi_current = 0
+        iz_current = 0
+        ray_path = 0
+        for it in range(n):
+            t = (it + 0.5) * dt
+            x = start.x + direction.x * t  # x coordinates of the points
+            y = start.y + direction.y * t  # y coordinates of the points
+            z = start.z + direction.z * t  # z coordinates of the points
+            iz = <int>(z / emitter.dz)  # Z-indices of grid cells, in which the points are located
+            r = sqrt(x * x + y * y)  # R coordinates of the points
+            ir = <int>((r - emitter.rmin) / emitter.dr)  # R-indices of grid cells, in which the points are located
+            if emitter.nphi == 1:  # axisymmetric case
+                iphi = 0
+            else:
+                phi = (180. / pi) * atan2(y, x)  # phi coordinates of the points (in the range [-180, 180))
+                phi = (phi + 360) % emitter.period  # moving into the [0, period) sector (periodic emitter)
+                iphi = <int>(phi / emitter.dphi)  # phi-indices of grid cells, in which the points are located
+            if ir != ir_current or iz != iz_current or iphi != iphi_current:  # we moved to the next cell
+                emitter.add_emission_to_mv(spectrum.samples_mv, ir_current, iphi_current, iz_current, ray_path)
+                ir_current = ir
+                iphi_current = iphi
+                iz_current = iz
+                ray_path = 0  # zeroing ray's path along the cell
+            ray_path += dt
+        emitter.add_emission_to_mv(spectrum.samples_mv, ir_current, iphi_current, iz_current, ray_path)
+
+        return spectrum
+
+
+cdef class CartesianRegularIntegrator(RegularGridIntegrator):
+    """
+    Integrates the spectral emissivity defined on a regular grid
+    in Cartesian coordinate system: :math:`(X, Y, Z)` along the ray's trajectory.
+    This integrator must be used with the `CartesianRegularEmitter` material class. 
+    This integrator does not perform interpolation, so the spectral emissivity at
+    any spatial point along the ray's trajectory is equal to that of the grid cell
+    where this point is located.
+    """
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
+                             InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
+                             AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world):
+
+        cdef:
+            Point3D start, end
+            Vector3D direction
+            int it, ix, iy, iz, ix_current, iy_current, iz_current, n
+            double length, t, dt, x, y, z, ray_path
+            CartesianRegularEmitter emitter
+
+        if not isinstance(material, CartesianRegularEmitter):
+            raise TypeError('Only CartesianRegularEmitter is supported by CartesianRegularIntegrator')
+
+        emitter = material
+        # Building the cache if required
+        emitter.cache_build(ray.get_min_wavelength(), ray.get_max_wavelength(), ray.get_bins())
+
+        if emitter.cache_empty():  # material does not emit at this wavelength range
+            return spectrum
+
+        # Determining direction of integration and effective integration step
+        start = start_point.transform(world_to_primitive)  # start point in local coordinates
+        end = end_point.transform(world_to_primitive)  # end point in local coordinates
+        direction = start.vector_to(end)  # direction of integration
+        length = direction.get_length()  # integration length
+        if length < 0.1 * self._step:  # return if ray's path is too short
+            return spectrum
+        direction = direction.normalise()  # normalized direction
+        n = max(self._min_samples, <int>(length / self._step))  # number of points along ray's trajectory
+        dt = length / n  # integration step
+
+        # Starting integrations
+        ix_current = 0
+        iy_current = 0
+        iz_current = 0
+        ray_path = 0
+        for it in range(n):
+            t = (it + 0.5) * dt
+            x = start.x + direction.x * t  # x coordinates of the points
+            y = start.y + direction.y * t  # y coordinates of the points
+            z = start.z + direction.z * t  # z coordinates of the points
+            ix = <int>(x / emitter.dx)  # X-indices of grid cells, in which the points are located
+            iy = <int>(y / emitter.dy)  # Y-indices of grid cells, in which the points are located
+            iz = <int>(z / emitter.dz)  # Z-indices of grid cells, in which the points are located
+            if ix != ix_current or iy != iy_current or iz != iz_current:  # we moved to the next cell
+                emitter.add_emission_to_mv(spectrum.samples_mv, ix_current, iy_current, iz_current, ray_path)
+                ix_current = ix
+                iy_current = iy
+                iz_current = iz
+                ray_path = 0  # zeroing ray's path along the cell
+            ray_path += dt
+        emitter.add_emission_to_mv(spectrum.samples_mv, ix_current, iy_current, iz_current, ray_path)
+
+        return spectrum
+
+
+cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
+    """
+    Basic class for the emitters defined on a regular 3D grid.
+    The emission anywhere outside the specified grid is zero.
+
+    :param tuple grid_shape: The number of grid cells along each direction.
+    :param tuple grid_steps: The sizes of grid cells along each direction.
+    :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
+        emission defined on a regular 3D grid in :math:`W/(str\,m^3\,nm)` (contineous
+        spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        Spectral emission can be provided either for selected cells of the regular
+        grid (2D array or sparse matrix) or for all grid cells (4D array).
+        Note that if provided as a 2D array (or sparse matrix), the spatial index `(i, j, k)`
+        must be flattened in a row-major order:
+        `iflat = grid_shape[1] * grid_shape[2] * i + grid_shape[2] * j + k`.
+        Regardless of the form in which the emission is provided, the last axis is the
+        spectral one.  The emission will be stored as a сompressed sparse column matrix
+        (`scipy.sparse.csc_matrix`). To reduce memory consumption, provide it as a `csc_matrix`.
+    :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
+        provided emission array. The size of this array must be equal to `emission.shape[-1]`.
+        Initialisation will be faster if this array contains monotonically increasing values.
+    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+        Defaults to `contineous=True`.
+    :param bool extrapolate: If True, the emission outside the provided spectral range
+        will be equal to the emission at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+        This parameter is ignored if `contineous=False`.
+    :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
+        float64, thus saving the memory.
+    :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator,
+        defaults to `integrator=NumericalIntegrator()`.
+
+    :ivar tuple grid_shape: The shape of regular grid.
+    :ivar tuple grid_steps: The sizes of grid cells along each direction.
+    :ivar csc_matrix ~.emission: The emission defined on a regular grid stored as a a сompressed
+        sparse column matrix (`scipy.sparse.csc_matrix`).
+    :ivar np.ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
+    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+    :ivar bool cache_32bit: Defines whether the cached data is stored in float32 (True) or
+        float64 (False).
+    :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
+        provided wavelength range (`True`) or not (`False`). Ignored if `contineous=False`.
+    :ivar int nvoxel: Total number of grid cells in the spatial grid.
+    """
+
+    def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
+                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
+
+        cdef:
+            np.ndarray indx_sorted
+            double step
+            int i
+
+        for step in grid_steps:
+            if step <= 0:
+                raise ValueError('Grid steps must be > 0.')
+        self._grid_steps = grid_steps
+
+        for i in grid_shape:
+            if i <= 0:
+                raise ValueError('Grid sizes must be > 0.')
+        if grid_shape[0] * grid_shape[1] * grid_shape[2] > np.iinfo('int32').max:
+            raise ValueError('Grids with more than %d cells are not supported.' % np.iinfo('int32').max +
+                             'Divide the grid into several parts and distribure it between mutiple emitters.')
+        self._grid_shape = grid_shape
+
+        self.nvoxel = self._grid_shape[0] * self._grid_shape[1] * self._grid_shape[2]
+
+        if emission.ndim == 2:
+            if emission.shape[0] != self.nvoxel:
+                raise ValueError("The number of rows in 'emission' array does not match the grid size.")
+            self.emission = csc_matrix(emission)  # this does not create a copy if emission is already a csc_matrix
+
+        elif emission.ndim == 4:
+            if emission.shape[0] != self._grid_shape[0] or emission.shape[1] != self._grid_shape[1] or emission.shape[2] != self._grid_shape[2]:
+                raise ValueError("The shape of 'emission' array does not match the grid shape.")
+            self.emission = csc_matrix(emission.reshape(self.nvoxel, emission.shape[3]))
+
+        else:
+            raise ValueError("Argument 'emission' must be a 4D or 2D array.")
+
+        if wavelengths.size != self.emission.shape[1]:
+            raise ValueError("The size of 'wavelengths' array does not match 'emission.shape[-1]'.")
+        if np.any(wavelengths < 0):
+            raise ValueError("Wavelengths must be >= 0.")
+
+        if np.any(np.diff(wavelengths) < 0):  # sorting the arrays if required
+            indx_sorted = np.argsort(wavelengths)
+            self.wavelengths = wavelengths[indx_sorted].astype(np.float64)
+            self.emission = self.emission[:, indx_sorted]
+        else:
+            self.wavelengths = wavelengths.astype(np.float64)
+
+        self._wavelengths_mv = self.wavelengths
+
+        self.contineous = contineous
+        self._extrapolate = extrapolate if self.contineous else False
+        self._cache_32bit = cache_32bit
+
+        self._cache_init()
+
+        super().__init__(integrator)
+
+    @property
+    def extrapolate(self):
+        return self._extrapolate
+
+    @extrapolate.setter
+    def extrapolate(self, bint value):
+        self._extrapolate = value if self.contineous else False
+
+    @property
+    def cache_32bit(self):
+        return self._cache_32bit
+
+    @cache_32bit.setter
+    def cache_32bit(self, bint value):
+        if self._cache_32bit != value:
+            self._cache_init()
+        self._cache_32bit = value
+
+    @cython.nonecheck(False)
+    cdef int get_voxel_index(self, int i, int j, int k) nogil:
+        """
+        Returns a flattened voxel index for provided i, j, k values.
+        """
+
+        if i < 0 or i >= self._grid_shape[0] or j < 0 or j >= self._grid_shape[1] or k < 0 or k >= self._grid_shape[2]:
+            return -1  # out of grid
+
+        return i * self._grid_shape[1] * self._grid_shape[2] + j * self._grid_shape[2] + k
+
+    cpdef int voxel_index(self, int i, int j, int k):
+        """
+        Returns a flattened voxel index for provided i, j, k values.
+        """
+
+        return self.get_voxel_index(i, j, k)
+
+    cdef void _cache_init(self):
+        """
+        Initialises the cache.
+        """
+
+        # initialise cache with invalid values
+        self._cache = None
+        self.cache_data_32_mv = None
+        self.cache_indptr_32_mv = None
+        self.cache_indices_32_mv = None
+        self.cache_data_64_mv = None
+        self.cache_indptr_64_mv = None
+        self.cache_indices_64_mv = None
+        self.cache_32bit_indices = True  # unlike _cache_32bit, this parameter is not controlled by user
+        self._cache_data_size = -1
+        self._cache_min_wvl = -1
+        self._cache_max_wvl = -1
+        self._cache_num_samp = -1
+
+    cpdef bint cache_valid(self, double min_wavelength, double max_wavelength, int bins):
+        """
+        Returns true if a suitable cached data are available.
+
+        :param float min_wavelength: The minimum wavelength in nanometers.
+        :param float max_wavelength: The maximum wavelength in nanometers.
+        :param int bins: The number of spectral bins.
+        """
+
+        return (
+            self._cache_min_wvl == min_wavelength and
+            self._cache_max_wvl == max_wavelength and
+            self._cache_num_samp == bins
+        )
+
+    cpdef bint cache_empty(self):
+        """
+        Returns true if the cached data does not contain non-zero elements or the cache is not
+        built.
+        """
+
+        return self._cache_data_size <= 0
+
+    cpdef void cache_override(self, object cache, double min_wavelength, double max_wavelength):
+        """
+        Overrides the cache with the provided compressed sparse row matrix.
+
+        :param csr_matrix cache: The cache pre-calculated for the spectral properties of rays.
+        :param float min_wavelength: The minimum wavelength in nanometers.
+        :param float max_wavelength: The maximum wavelength in nanometers.
+
+        Use this in case of insufficient memory.
+        .. code-block:: pycon
+          >>> grid_size = grid_shape[0] * grid_shape[1] * grid_shape[2]
+          >>> wavelengths = np.ones(1)
+          >>> emission = csc_matrix((grid_size, 1))
+          >>> emitter = RegularGridEmitter(grid_shape, grid_steps, emission, wavelengths)
+          >>> emitter.cache_override(cache, camera.min_wavelength, camera.max_wavelength)
+
+        Note that `cache.shape` must be equal to `(grid_size, camera.spectral_bins)`.
+        This solution will work only if dispesive rendering is off (`camera.spectral_rays = 1`)
+        and spectral properties of rays do not change during rendering.
+        """
+
+        if not isinstance(cache, csr_matrix):
+            raise TypeError("Argument 'cache' must be a 'csr_matrix' instance.")
+
+        if cache.shape[0] != self.nvoxel:
+            raise ValueError('Provided cache matrix does not match the grid size.')
+
+        self._cache_init()  # deleting current cache
+
+        # if cache.indptr.dtype != np.int32 or cache.indices.dtype != np.int32:
+        #     raise ValueError('Provided cache matrix must have np.int32 indices.' +
+        #                      'Divide the grid into several parts and distribure it between mutiple emitters if it is too large.')
+        if cache.indptr.dtype == np.int32:
+            self.cache_32bit_indices = True
+        else:
+            self.cache_32bit_indices = False
+
+        if cache.data.dtype == np.float32:
+            self._cache_32bit = True
+        elif cache.data.dtype == np.float64:
+            self._cache_32bit = False
+        else:
+            raise ValueError('Cache data must be in float32 or float64.')
+
+        self._cache = cache
+
+        if self._cache_32bit:
+            self.cache_data_32_mv = self._cache.data
+        else:
+            self.cache_data_64_mv = self._cache.data
+
+        if self.cache_32bit_indices:
+            self.cache_indptr_32_mv = self._cache.indptr
+            self.cache_indices_32_mv = self._cache.indices
+        else:
+            self.cache_indptr_64_mv = self._cache.indptr
+            self.cache_indices_64_mv = self._cache.indices
+
+        self._cache_data_size = self._cache.data.size
+        self._cache_min_wvl = min_wavelength
+        self._cache_max_wvl = max_wavelength
+        self._cache_num_samp = self._cache.shape[1]
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.initializedcheck(False)
+    cpdef void cache_build(self, double min_wavelength, double max_wavelength, int bins, bint forced=False):
+        """
+        Builds a new cache if the old one does not match the wavelength range.
+
+        :param float min_wavelength: The minimum wavelength in nanometers.
+        :param float max_wavelength: The maximum wavelength in nanometers.
+        :param int bins: The number of spectral bins.
+        :param bool forces: Rebuild the cache even if the old cache matches the wavelength
+            range, defaults to `forced=False`
+        """
+
+        cdef:
+            object bin_integral
+            np.ndarray data, row_ind, col_inds
+            double delta, lower, upper
+            int i
+
+        if (not forced) and self.cache_valid(min_wavelength, max_wavelength, bins):
+            return
+
+        self._cache_init()  # deleting current cache
+
+        dtype = np.float32 if self._cache_32bit else np.float64
+
+        data = np.array([], dtype=dtype)
+        # neither number of grid cells nor number of spectral bins exceeds max(int32), so int32 is ok for both row_ind and col_ind
+        row_ind = np.array([], dtype=np.int32)
+        col_ind = np.array([], dtype=np.int32)
+        delta = (max_wavelength - min_wavelength) / bins
+        lower = min_wavelength
+        for i in range(bins):
+            upper = min_wavelength + (i + 1) * delta
+            bin_integral = self.integrate(lower, upper)
+            data = np.concatenate((data, (bin_integral.data / delta).astype(dtype)))
+            col_ind = np.concatenate((col_ind, i * np.ones(bin_integral.data.size, dtype=np.int32)))
+            row_ind = np.concatenate((row_ind, bin_integral.indices))  # bin_integral.indices is always int32 (1-column array)
+            lower = upper
+
+        self._cache = csr_matrix((data, (row_ind, col_ind)), shape=(self.nvoxel, bins), dtype=dtype)
+
+        if self._cache.indptr.dtype == np.int64:
+            self.cache_32bit_indices = False  # cache_32bit_indices is True after _cache_init()
+
+        if self._cache_32bit:
+            self.cache_data_32_mv = self._cache.data
+        else:
+            self.cache_data_64_mv = self._cache.data
+
+        if self.cache_32bit_indices:
+            self.cache_indptr_32_mv = self._cache.indptr
+            self.cache_indices_32_mv = self._cache.indices
+        else:
+            self.cache_indptr_64_mv = self._cache.indptr
+            self.cache_indices_64_mv = self._cache.indices
+
+        self._cache_data_size = self._cache.data.size
+        self._cache_min_wvl = min_wavelength
+        self._cache_max_wvl = max_wavelength
+        self._cache_num_samp = bins
+
+    cpdef object integrate(self, double min_wavelength, double max_wavelength):
+        """
+        Integrate the emission in the specified wavelength range and returns the result in the
+        form of one-column `csc_matrix`.
+
+        :param float min_wavelength: The minimum wavelength in nanometers.
+        :param float max_wavelength: The maximum wavelength in nanometers.
+
+        :return: Integrated emission in :math:`W/(str\,m^3)`.
+        """
+
+        if self.contineous:
+            return integrate_contineous(self._wavelengths_mv, self.emission, min_wavelength, max_wavelength, self._extrapolate)
+        else:
+            return integrate_delta_function(self._wavelengths_mv, self.emission, min_wavelength, max_wavelength)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cdef void add_emission_to_mv(self, double[::1] samples_mv, int i, int j, int k, double ray_path) nogil:
+        """
+        Adds to the provided memoryview the spectral emission of the specified spatial cell,
+        multiplied by the provided distance, travelled by ray through the cell.
+
+        Call this function only after the cache is built!!!
+
+        :param double[::1] samples_mv: Memoryview of the array with nbins elements.
+        :param int i: 1st index of the grid.
+        :param int j: 2nd index of the grid.
+        :param int k: 3rd index of the grid.
+        :param double ray_path: Distance, travelled by ray through the cell.
+        """
+
+        cdef:
+            int ivoxel, i32
+            long i64
+
+        # it's slightly faster than call get_voxel_index()
+        if i < 0 or i >= self._grid_shape[0] or j < 0 or j >= self._grid_shape[1] or k < 0 or k >= self._grid_shape[2]:
+            return
+
+        ivoxel = i * self._grid_shape[1] * self._grid_shape[2] + j * self._grid_shape[2] + k
+
+        if self._cache_32bit:
+            if self.cache_32bit_indices:
+                for i32 in range(self.cache_indptr_32_mv[ivoxel], self.cache_indptr_32_mv[ivoxel + 1]):
+                    samples_mv[self.cache_indices_32_mv[i32]] += ray_path * self.cache_data_32_mv[i32]
+            else:
+                for i64 in range(self.cache_indptr_64_mv[ivoxel], self.cache_indptr_64_mv[ivoxel + 1]):
+                    samples_mv[self.cache_indices_64_mv[i64]] += ray_path * self.cache_data_32_mv[i64]
+        else:
+            if self.cache_32bit_indices:
+                for i32 in range(self.cache_indptr_32_mv[ivoxel], self.cache_indptr_32_mv[ivoxel + 1]):
+                    samples_mv[self.cache_indices_32_mv[i32]] += ray_path * self.cache_data_64_mv[i32]
+            else:
+                for i64 in range(self.cache_indptr_64_mv[ivoxel], self.cache_indptr_64_mv[ivoxel + 1]):
+                    samples_mv[self.cache_indices_64_mv[i64]] += ray_path * self.cache_data_64_mv[i64]
+
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef void add_emission_to_array(self, np.ndarray samples, int i, int j, int k, double ray_path):
+        """
+        Adds to the provided memoryview the spectral emission of the specified spatial cell,
+        multiplied by the provided distance, travelled by ray through the cell.
+
+        Call this function only after the cache is built!!!
+
+        :param double[::1] samples_mv: Memoryview of the array with nbins elements.
+        :param int i: 1st index of the grid.
+        :param int j: 2nd index of the grid.
+        :param int k: 3rd index of the grid.
+        :param double ray_path: Distance, travelled by ray through the cell.
+        """
+
+        cdef:
+            double[::1] samples_mv
+
+        samples_mv = samples
+        self.add_emission_to_mv(samples_mv, i, j, k, ray_path)
+
+
+cdef class CylindricalRegularEmitter(RegularGridEmitter):
+
+    """
+    Spectral emitter defined on a regular 3D grid in cylindrical
+    coordinates: :math:`(R, \phi, Z)`. This emitter is periodic in :math:`\phi` direction.
+    The emission enywhere outsode the provided spatial grid is zero.
+
+    :param tuple grid_shape: The number of grid cells along each direction.
+    :param tuple grid_steps: The sizes of grid cells along each direction.
+    :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
+        emission defined on a regular :math:`(R, \phi, Z)` grid in :math:`W/(str\,m^3\,nm)`
+        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        Spectral emission can be provided either for selected cells of the regular
+        grid (2D array or sparse matrix) or for all grid cells (4D array).
+        Note that if provided as a 2D array (or sparse matrix), the spatial index `(ir, iphi, iz)`
+        must be flattened in a row-major order:
+        `iflat = grid_shape[1] * grid_shape[2] * ir + grid_shape[2] * iphi + iz`.
+        Regardless of the form in which the emission is provided, the last axis is the
+        spectral one.  The emission will be stored as a сompressed sparse column matrix
+        (`scipy.sparse.csc_matrix`). To reduce memory consumption, provide it as a `csc_matrix`.
+    :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
+        provided emission array. The size of this array must be equal to `emission.shape[-1]`.
+        Initialisation will be faster if this array contains monotonically increasing values.
+    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+        Defaults to `contineous=True`.
+    :param bool extrapolate: If True, the emission outside the provided spectral range
+        will be equal to the emission at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+        This parameter is ignored if `contineous=False`.
+    :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
+        float64, thus saving the memory.
+    :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator, defaults to
+        `CylindricalRegularIntegrator(step=0.25 * min(grid_steps[0], grid_steps[2]))`.
+    :param float rmin: Lower bound of grid in `R` direction (in meters), defaults to `rmin=0`.
+    
+    :ivar tuple grid_shape: The shape of regular grid.
+    :ivar tuple grid_steps: The sizes of grid cells along each direction.
+    :ivar csc_matrix ~.emission: The emission defined on a regular grid stored as a a сompressed
+        sparse column matrix (`scipy.sparse.csc_matrix`).
+    :ivar np.ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
+    :ivar int nvoxel: Total number of grid cells in the spatial grid.
+    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+    :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
+        provided wavelength range (`True`) or not (`False`).
+    :ivar bool cache_32bit: Defines whether the cached data is stored in float32 (True) or
+        float64 (False).
+    :ivar float period: The period in :math:`\phi` direction (equals to
+        `grid_shape[1] * grid_steps[1]`.
+    :ivar float rmin: Lower bound of grid in `R` direction.
+    :ivar float dr: The size of grid cell in `R` direction (equals to `grid_steps[0]`).
+    :ivar float dphi: The size of grid cell in :math:`\phi` direction (equals to `grid_steps[1]`).
+    :ivar float dz: The size of grid cell in `Z` direction (equals to `grid_steps[2]`). 
+
+    Continoues spectrum example:   
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, rotate
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import CylindricalRegularEmitter
+        >>> ### Contineous case ###
+        >>> # grid parameters
+        >>> rmin = 0
+        >>> rmax = 2.
+        >>> zmin = -0.25
+        >>> zmax = 0.25
+        >>> r, dr = np.linspace(rmin, rmax, 201, retstep=True)
+        >>> r = r[:-1] + 0.5 * dr  # moving to the grid cell centers
+        >>> grid_shape = (200, 1, 1)
+        >>> grid_steps = (dr, 360., zmax - zmin)
+        >>> integration_step = 0.05
+        >>> # spectral emission profile
+        >>> min_wavelength = 375.
+        >>> max_wavelength = 740.
+        >>> wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, 50,
+                                                        retstep=True)
+        >>> wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+        >>> wvl_range = min_wavelength - max_wavelength
+        >>> shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+        >>> emission = np.cos(shift[None, None, None, :] * radius[:, None, None, None])**4
+        >>> # scene
+        >>> world = World()
+        >>> material = CylindricalRegularEmitter(grid_shape, grid_steps, emission,
+                                                 wavelengths, rmin=rmin)
+        >>> bounding_box = Subtract(Cylinder(rmax, zmax - zmin), Cylinder(rmin, zmax - zmin),
+                                    material=material, parent=world)  # bounding primitive
+        >>> bounding_box.transform = translate(-rmax, -rmax + 1., zmin) * rotate(30, 0, 0)
+        ...
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                 camera.spectral_bins)
+
+    Discrete spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate
+        >>> from raysect.optical.observer import SpectralRadiancePipeline2D
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import CylindricalRegularEmitter
+        >>> # Assume that the files 'Be_4574A.npy' and 'Be_527A.npy' contain the emissions
+        >>> # (in W / m^3) of Be I (3d1 1D2 -> 2p1 1P1) and Be II (4s1 2S0.5 -> 3p1 2P2.5)
+        >>> # spectral lines defined on a regular cylindrical grid: 3.5 m < R < 9 m,
+        >>> # 0 < phi < 20 deg, -5 m < Z < 5 m, and periodic in phi direction.
+        >>> emission_4574 = np.load('Be_4574A.npy')
+        >>> emission_5272 = np.load('Be_5272A.npy')
+        >>> wavelengths = np.array([457.4, 527.2])
+        >>> # Grid properties
+        >>> rmin = 3.5
+        >>> rmax = 9.
+        >>> phi_period = 20.
+        >>> zmin = -5.
+        >>> zmax = 5.
+        >>> grid_shape = emission_4574.shape
+        >>> grid_steps = ((rmax - rmin) / grid_shape[0],
+                          phi_period / grid_shape[1],
+                          (zmax - zmin) / grid_shape[2])
+        >>> emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], 2))
+        >>> emission[:, :, :, 0] = emission_4574 / (4. * np.pi)  # to W/(m^3 str)
+        >>> emission[:, :, :, 1] = emission_5272 / (4. * np.pi)
+        >>> # Creating the scene
+        >>> world = World()
+        >>> pipeline = SpectralRadiancePipeline2D()
+        >>> material = CylindricalRegularEmitter(grid_shape, grid_steps, memission,
+                                                 wavelengths, rmin=rmin, contineous=False)
+        >>> bounding_box = Subtract(Cylinder(rmax, zmax - zmin),
+                                    Cylinder(rmin, zmax - zmin),
+                                    material=material, parent=world)  # bounding primitive
+        >>> bounding_box.transform = translate(0, 0, zmin)
+        ...
+        >>> camera.spectral_bins = 15
+        >>> camera.min_wavelength = 457.
+        >>> camera.max_wavelength = 528.
+        >>> delta_wavelength = (camera.max_wavelength - camera.min_wavelength)/camera.spectral_bins
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                 camera.spectral_bins)
+        ...
+        >>> # If reflections do not change the wavelength, the results for each spectral line
+        >>> # can be obtained in W/(m^2 str) in the following way.
+        >>> radiance_4574 = pipeline.frame.mean[:, :, 0] * delta_wavelength
+        >>> radiance_5272 = pipeline.frame.mean[:, :, -1] * delta_wavelength
+    """
+
+    def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
+                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None, double rmin=0):
+
+        if rmin < 0:
+            raise ValueError("Attribute 'rmin' must be >= 0.")
+
+        integrator = integrator or CylindricalRegularIntegrator(0.25 * min(grid_steps[0], grid_steps[2]))
+        super().__init__(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+                         cache_32bit=cache_32bit, integrator=integrator)
+
+        cdef:
+            double period
+
+        self.rmin = rmin
+
+        self.dr = self._grid_steps[0]
+        self.dphi = self._grid_steps[1]
+        self.dz = self._grid_steps[2]
+
+        self.nr = self._grid_shape[0]
+        self.nphi = self._grid_shape[1]
+        self.nz = self._grid_shape[2]
+
+        period = self.nphi * self.dphi
+        if 360. % period > 1.e-3:
+            raise ValueError("The period %.3f (grid_shape[1] * grid_steps[1]) is not a multiple of 360." % period)
+        self.period = period
+
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
+                                     World world, Ray ray, Primitive primitive,
+                                     AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world):
+
+        cdef:
+            int ir, iphi, iz
+            double r, phi, delta_wavelength
+
+        # Building the cache if required
+        self.cache_build(ray.get_min_wavelength(), ray.get_max_wavelength(), ray.get_bins())
+
+        if self.cache_empty():  # emitter does not emit at this wavelength range
+            return spectrum
+
+        # Obtaining the index of the grid cell, where the point is located
+        iz = <int>(point.z / self.dz)  # Z-index of grid cell, in which the point is located
+        r = sqrt(point.x * point.x + point.y * point.y)  # R coordinates of the points
+        ir = <int>((r - self.rmin) / self.dr)  # R-index of grid cell, in which the points is located
+        if self.nphi == 1:  # axisymmetric case
+            iphi = 0
+        else:
+            phi = (180. / pi) * atan2(point.y, point.x)  # phi coordinates of the points (in the range [-180, 180))
+            phi = (phi + 360) % self.period  # moving into the [0, period) sector (periodic emitter)
+            iphi = <int>(phi / self.dphi)  # phi-index of grid cell, in which the point is located
+        self.add_emission_to_mv(spectrum.samples_mv, ir, iphi, iz, 1.0)
+
+        return spectrum
+
+
+cdef class CartesianRegularEmitter(RegularGridEmitter):
+
+    """
+    Spectral emitter defined on a regular 3D grid in Cartesian
+    coordinates. The emission enywhere outsode the provided spatial grid is zero.
+
+    :param tuple grid_shape: The number of grid cells along each direction.
+    :param tuple grid_steps: The sizes of grid cells along each direction.
+    :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
+        emission defined on a regular :math:`(X, Y, Z)` grid in :math:`W/(str\,m^3\,nm)`
+        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        Spectral emission can be provided either for selected cells of the regular
+        grid (2D array or sparse matrix) or for all grid cells (4D array).
+        Note that if provided as a 2D array (or sparse matrix), the spatial index `(ix, iy, iz)`
+        must be flattened in a row-major order:
+        `iflat = grid_shape[1] * grid_shape[2] * ix + grid_shape[2] * iy + iz`.
+        Regardless of the form in which the emission is provided, the last axis is the
+        spectral one.  The emission will be stored as a сompressed sparse column matrix
+        (`scipy.sparse.csc_matrix`). To reduce memory consumption, provide it as a `csc_matrix`.
+    :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
+        provided emission array. The size of this array must be equal to `emission.shape[-1]`.
+        Initialisation will be faster if this array contains monotonically increasing values.
+    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+        Defaults to `contineous=True`.
+    :param bool extrapolate: If True, the emission outside the provided spectral range
+        will be equal to the emission at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+        This parameter is ignored if `contineous=False`.
+    :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
+        float64, thus saving the memory.
+    :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator, defaults to
+        `CartesianRegularIntegrator(step=0.25 * min(grid_steps))`.
+
+    :ivar tuple grid_shape: The shape of regular grid.
+    :ivar tuple grid_steps: The sizes of grid cells along each direction.
+    :ivar csc_matrix ~.emission: The emission defined on a regular grid stored as a a сompressed
+        sparse column matrix (`scipy.sparse.csc_matrix`).
+    :ivar np.ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
+    :ivar int nvoxel: Total number of grid cells in the spatial grid.
+    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+    :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
+        provided wavelength range (`True`) or not (`False`).
+    :ivar bool cache_32bit: Defines whether the cached data is stored in float32 (True) or
+        float64 (False).
+    :ivar float dx: The size of grid cell in `X` direction (equals to `grid_steps[0]`).
+    :ivar float dy: The size of grid cell in `Y` direction (equals to `grid_steps[1]`).
+    :ivar float dz: The size of grid cell in `Z` direction (equals to `grid_steps[2]`).
+
+    Continoues spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, rotate
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import CartesianRegularEmitter
+        >>> # grid parameters
+        >>> xmin = ymin = -1.
+        >>> xmax = ymax = 1.
+        >>> zmin = -0.25
+        >>> zmax = 0.25
+        >>> grid_shape = (100, 100, 1)
+        >>> x, dx = np.linspace(xmin, xmax, grid_shape[0] + 1, retstep=True)
+        >>> y, dy = np.linspace(ymin, ymax, grid_shape[1] + 1, retstep=True)
+        >>> grid_steps = (dx, dy, zmax - zmin)
+        >>> x = x[:-1] + 0.5 * dx  # moving to the grid cell centers
+        >>> y = y[:-1] + 0.5 * dy
+        >>> # spectral emission profile
+        >>> min_wavelength = 375.
+        >>> max_wavelength = 740.
+        >>> wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, 50,
+                                                        retstep=True)
+        >>> wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+        >>> wvl_range = min_wavelength - max_wavelength
+        >>> shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+        >>> radius = np.sqrt((x * x)[:, None] + (y * y)[None, :])
+        >>> emission = np.cos(shift[None, None, None, :] * radius[:, :, None, None])**4
+        >>> # scene
+        >>> world = World()
+        >>> material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths)
+        >>> bounding_box = Box(lower=Point3D(0, 0, 0),
+                               upper=Point3D(xmax - xmin, ymax - ymin, zmax - zmin),
+                               material=material, parent=world)
+        >>> material.transform = (translate(0, 1., 0) * rotate(30, 0, 0) *
+                                  translate(xmin, ymin, zmin))
+        ...
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                 camera.spectral_bins)
+
+    Discrete spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, Point3D
+        >>> from raysect.primitive import Box
+        >>> from raysect.optical.observer import SpectralRadiancePipeline2D
+        >>> from raysect.optical.material import CartesianRegularEmitter
+        >>> # Assume that the files 'Be_4574A.npy' and 'Be_527A.npy' contain the emissions
+        >>> # (in W / m^3) of Be I (3d1 1D2 -> 2p1 1P1) and Be II (4s1 2S0.5 -> 3p1 2P2.5)
+        >>> # spectral lines defined on a regular Cartesian grid: -3 m < X < 3 m,
+        >>> # -3 m < Y < 3 m and -6 m < Z < 6 m.
+        >>> emission_4574 = np.load('Be_4574A.npy')
+        >>> emission_5272 = np.load('Be_5272A.npy')
+        >>> # Grid properties
+        >>> xmin = ymin = -3.
+        >>> xmax = ymax = 3.
+        >>> zmin = -6.
+        >>> zmax = 6.
+        >>> grid_shape = emission_4574.shape
+        >>> grid_steps = ((xmax - xmin) / grid_shape[0],
+                          (ymax - ymin) / grid_shape[1],
+                          (zmax - zmin) / grid_shape[2])
+        >>> emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], 2))
+        >>> emission[:, :, :, 0] = emission_4574 / (4. * np.pi)  # to W/(m^3 str)
+        >>> emission[:, :, :, 1] = emission_5272 / (4. * np.pi)
+        >>> # Creating the scene
+        >>> world = World()
+        >>> pipeline = SpectralRadiancePipeline2D()
+        >>> material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths,
+                                               contineous=False)
+        >>> bounding_box = Box(lower=Point3D(0, 0, 0),
+                               upper=Point3D(xmax - xmin, ymax - ymin, zmax - zmin),
+                               material=material, parent=world,
+                               transform=translate(xmin, ymin, zmin))
+        ...
+        >>> camera.spectral_bins = 15
+        >>> camera.min_wavelength = 457
+        >>> camera.max_wavelength = 528
+        >>> delta_wavelength = (camera.max_wavelength - camera.min_wavelength)/camera.spectral_bins
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                 camera.spectral_bins)
+        ...
+        >>> # If reflections do not change the wavelength, the results for each spectral line
+        >>> # can be obtained in W/(m^2 sr) in the following way.
+        >>> radiance_4574 = pipeline.frame.mean[:, :, 0] * delta_wavelength
+        >>> radiance_5272 = pipeline.frame.mean[:, :, -1] * delta_wavelength
+    """
+
+    def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
+                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
+
+        integrator = integrator or CartesianRegularIntegrator(0.25 * min(grid_steps))
+        super().__init__(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+                         cache_32bit=cache_32bit, integrator=integrator)
+        self.dx = self._grid_steps[0]
+        self.dy = self._grid_steps[1]
+        self.dz = self._grid_steps[2]
+
+        self.nx = self._grid_shape[0]
+        self.ny = self._grid_shape[1]
+        self.nz = self._grid_shape[2]
+
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
+                                     World world, Ray ray, Primitive primitive,
+                                     AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world):
+
+        cdef:
+            int ix, iy, iz
+
+        # Building the cache if required
+        self.cache_build(ray.get_min_wavelength(), ray.get_max_wavelength(), ray.get_bins())
+
+        if self.cache_empty():  # emitter does not emit at this wavelength range
+            return spectrum
+
+        ix = <int>(point.x / self.dx)  # X-index of grid cell, in which the point is located
+        iy = <int>(point.y / self.dy)  # Y-index of grid cell, in which the point is located
+        iz = <int>(point.z / self.dz)  # Z-index of grid cell, in which the point is located
+        self.add_emission_to_mv(spectrum.samples_mv, ix, iy, iz, 1.0)
+
+        return spectrum

--- a/raysect/optical/material/emitter/regular_grid_emitters.pyx
+++ b/raysect/optical/material/emitter/regular_grid_emitters.pyx
@@ -74,7 +74,7 @@ from scipy.sparse import csr_matrix, csc_matrix
 from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
 from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
 from libc.math cimport sqrt, atan2, M_PI as pi
-from .regular_grid_utility cimport integrate_contineous, integrate_delta_function
+from .regular_grid_utility cimport integrate_continuous, integrate_delta_function
 cimport numpy as np
 cimport cython
 
@@ -277,7 +277,7 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
     :param tuple grid_shape: The number of grid cells along each direction.
     :param tuple grid_steps: The sizes of grid cells along each direction.
     :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
-        emission defined on a regular 3D grid in :math:`W/(str\,m^3\,nm)` (contineous
+        emission defined on a regular 3D grid in :math:`W/(str\,m^3\,nm)` (continuous
         spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
         Spectral emission can be provided either for selected cells of the regular
         grid (2D array or sparse matrix) or for all grid cells (4D array).
@@ -290,13 +290,13 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
     :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
         provided emission array. The size of this array must be equal to `emission.shape[-1]`.
         Initialisation will be faster if this array contains monotonically increasing values.
-    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :param bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
-        Defaults to `contineous=True`.
+        Defaults to `continuous=True`.
     :param bool extrapolate: If True, the emission outside the provided spectral range
         will be equal to the emission at the borders of this range (nearest-neighbour
         extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
-        This parameter is ignored if `contineous=False`.
+        This parameter is ignored if `continuous=False`.
     :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
         float64, thus saving the memory.
     :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator,
@@ -307,17 +307,17 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
     :ivar csc_matrix ~.emission: The emission defined on a regular grid stored as a a сompressed
         sparse column matrix (`scipy.sparse.csc_matrix`).
     :ivar ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
-    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :ivar bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
     :ivar bool cache_32bit: Defines whether the cached data is stored in float32 (True) or
         float64 (False).
     :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
-        provided wavelength range (`True`) or not (`False`). Ignored if `contineous=False`.
+        provided wavelength range (`True`) or not (`False`). Ignored if `continuous=False`.
     :ivar int nvoxel: Total number of grid cells in the spatial grid.
     """
 
     def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
-                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
+                 bint continuous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
 
         cdef:
             np.ndarray indx_sorted
@@ -364,8 +364,8 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
 
         self._wavelengths_mv = self.wavelengths
 
-        self.contineous = contineous
-        self._extrapolate = extrapolate if self.contineous else False
+        self.continuous = continuous
+        self._extrapolate = extrapolate if self.continuous else False
         self._cache_32bit = True if emission.dtype == np.float32 else cache_32bit
 
         self._cache_init()
@@ -378,7 +378,7 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
 
     @extrapolate.setter
     def extrapolate(self, bint value):
-        self._extrapolate = value if self.contineous else False
+        self._extrapolate = value if self.continuous else False
 
     @property
     def cache_32bit(self):
@@ -580,8 +580,8 @@ cdef class RegularGridEmitter(InhomogeneousVolumeEmitter):
         :return: Integrated emission in :math:`W/(str\,m^3)`.
         """
 
-        if self.contineous:
-            return integrate_contineous(self._wavelengths_mv, self.emission, min_wavelength, max_wavelength, self._extrapolate)
+        if self.continuous:
+            return integrate_continuous(self._wavelengths_mv, self.emission, min_wavelength, max_wavelength, self._extrapolate)
         else:
             return integrate_delta_function(self._wavelengths_mv, self.emission, min_wavelength, max_wavelength)
 
@@ -670,7 +670,7 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
     :param tuple grid_steps: The sizes of grid cells along each direction.
     :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
         emission defined on a regular :math:`(R, \phi, Z)` grid in :math:`W/(str\,m^3\,nm)`
-        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        (continuous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
         Spectral emission can be provided either for selected cells of the regular
         grid (2D array or sparse matrix) or for all grid cells (4D array).
         Note that if provided as a 2D array (or sparse matrix), the spatial index `(ir, iphi, iz)`
@@ -682,13 +682,13 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
     :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
         provided emission array. The size of this array must be equal to `emission.shape[-1]`.
         Initialisation will be faster if this array contains monotonically increasing values.
-    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :param bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
-        Defaults to `contineous=True`.
+        Defaults to `continuous=True`.
     :param bool extrapolate: If True, the emission outside the provided spectral range
         will be equal to the emission at the borders of this range (nearest-neighbour
         extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
-        This parameter is ignored if `contineous=False`.
+        This parameter is ignored if `continuous=False`.
     :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
         float64, thus saving the memory.
     :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator, defaults to
@@ -701,7 +701,7 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
         sparse column matrix (`scipy.sparse.csc_matrix`).
     :ivar ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
     :ivar int nvoxel: Total number of grid cells in the spatial grid.
-    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :ivar bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
     :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
         provided wavelength range (`True`) or not (`False`).
@@ -722,7 +722,7 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
         >>> from raysect.optical import World, translate, rotate
         >>> from raysect.primitive import Cylinder, Subtract
         >>> from raysect.optical.material import CylindricalRegularEmitter
-        >>> ### Contineous case ###
+        >>> ### continuous case ###
         >>> # grid parameters
         >>> rmin = 0
         >>> rmax = 2.
@@ -788,7 +788,7 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
         >>> world = World()
         >>> pipeline = SpectralRadiancePipeline2D()
         >>> material = CylindricalRegularEmitter(grid_shape, grid_steps, memission,
-                                                 wavelengths, rmin=rmin, contineous=False)
+                                                 wavelengths, rmin=rmin, continuous=False)
         >>> bounding_box = Subtract(Cylinder(rmax, zmax - zmin),
                                     Cylinder(rmin, zmax - zmin),
                                     material=material, parent=world)  # bounding primitive
@@ -810,13 +810,13 @@ cdef class CylindricalRegularEmitter(RegularGridEmitter):
     """
 
     def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
-                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None, double rmin=0):
+                 bint continuous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None, double rmin=0):
 
         if rmin < 0:
             raise ValueError("Attribute 'rmin' must be >= 0.")
 
         integrator = integrator or CylindricalRegularIntegrator(0.25 * min(grid_steps[0], grid_steps[2]))
-        super().__init__(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+        super().__init__(grid_shape, grid_steps, emission, wavelengths, continuous=continuous, extrapolate=extrapolate,
                          cache_32bit=cache_32bit, integrator=integrator)
 
         cdef:
@@ -880,7 +880,7 @@ cdef class CartesianRegularEmitter(RegularGridEmitter):
     :param tuple grid_steps: The sizes of grid cells along each direction.
     :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
         emission defined on a regular :math:`(X, Y, Z)` grid in :math:`W/(str\,m^3\,nm)`
-        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        (continuous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
         Spectral emission can be provided either for selected cells of the regular
         grid (2D array or sparse matrix) or for all grid cells (4D array).
         Note that if provided as a 2D array (or sparse matrix), the spatial index `(ix, iy, iz)`
@@ -892,13 +892,13 @@ cdef class CartesianRegularEmitter(RegularGridEmitter):
     :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
         provided emission array. The size of this array must be equal to `emission.shape[-1]`.
         Initialisation will be faster if this array contains monotonically increasing values.
-    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :param bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
-        Defaults to `contineous=True`.
+        Defaults to `continuous=True`.
     :param bool extrapolate: If True, the emission outside the provided spectral range
         will be equal to the emission at the borders of this range (nearest-neighbour
         extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
-        This parameter is ignored if `contineous=False`.
+        This parameter is ignored if `continuous=False`.
     :param bool cache_32bit: If True, the cached data will be stored in float32 instead of
         float64, thus saving the memory.
     :param raysect.optical.material.VolumeIntegrator integrator: Volume integrator, defaults to
@@ -910,7 +910,7 @@ cdef class CartesianRegularEmitter(RegularGridEmitter):
         sparse column matrix (`scipy.sparse.csc_matrix`).
     :ivar ndarray wavelengths: The sorted wavelengths corresponding to the emission array.
     :ivar int nvoxel: Total number of grid cells in the spatial grid.
-    :ivar bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :ivar bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
     :ivar bool extrapolate: Defines whether the emission spectrum is extrapolated outside the
         provided wavelength range (`True`) or not (`False`).
@@ -994,7 +994,7 @@ cdef class CartesianRegularEmitter(RegularGridEmitter):
         >>> world = World()
         >>> pipeline = SpectralRadiancePipeline2D()
         >>> material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths,
-                                               contineous=False)
+                                               continuous=False)
         >>> bounding_box = Box(lower=Point3D(0, 0, 0),
                                upper=Point3D(xmax - xmin, ymax - ymin, zmax - zmin),
                                material=material, parent=world,
@@ -1016,10 +1016,10 @@ cdef class CartesianRegularEmitter(RegularGridEmitter):
     """
 
     def __init__(self, tuple grid_shape, tuple grid_steps, object emission, np.ndarray wavelengths,
-                 bint contineous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
+                 bint continuous=True, bint extrapolate=True, bint cache_32bit=False, VolumeIntegrator integrator=None):
 
         integrator = integrator or CartesianRegularIntegrator(0.25 * min(grid_steps))
-        super().__init__(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+        super().__init__(grid_shape, grid_steps, emission, wavelengths, continuous=continuous, extrapolate=extrapolate,
                          cache_32bit=cache_32bit, integrator=integrator)
 
         self.dx = self._grid_steps[0]

--- a/raysect/optical/material/emitter/regular_grid_utility.pxd
+++ b/raysect/optical/material/emitter/regular_grid_utility.pxd
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2017, Dr Alex Meakins, Raysect Project
+# cython: language_level=3
+
+# Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,12 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .uniform import UniformSurfaceEmitter, UniformVolumeEmitter
-from .unity import UnitySurfaceEmitter, UnityVolumeEmitter
-from .homogeneous import HomogeneousVolumeEmitter
-from .inhomogeneous import InhomogeneousVolumeEmitter, VolumeIntegrator, NumericalIntegrator
-from .checkerboard import Checkerboard
-from .anisotropic import AnisotropicSurfaceEmitter
-from .regular_grid_emitters import RegularGridEmitter, CartesianRegularEmitter, CylindricalRegularEmitter
-from .regular_grid_emitters import RegularGridIntegrator, CartesianRegularIntegrator, CylindricalRegularIntegrator
-from .regular_grid_volumes import RegularGridVolume, RegularGridBox, RegularGridCylinder
+cdef object integrate_contineous(double[::1] x, object y, double x0, double x1, bint extrapolate=*)
+
+cdef object integrate_delta_function(double[::1] x, object y, double x0, double x1)

--- a/raysect/optical/material/emitter/regular_grid_utility.pxd
+++ b/raysect/optical/material/emitter/regular_grid_utility.pxd
@@ -29,6 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cdef object integrate_contineous(double[::1] x, object y, double x0, double x1, bint extrapolate=*)
+cdef object integrate_continuous(double[::1] x, object y, double x0, double x1, bint extrapolate=*)
 
 cdef object integrate_delta_function(double[::1] x, object y, double x0, double x1)

--- a/raysect/optical/material/emitter/regular_grid_utility.pyx
+++ b/raysect/optical/material/emitter/regular_grid_utility.pyx
@@ -42,7 +42,7 @@ cimport cython
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.initializedcheck(False)
-cdef object integrate_contineous(double[::1] x, object y, double x0, double x1, bint extrapolate=True):
+cdef object integrate_continuous(double[::1] x, object y, double x0, double x1, bint extrapolate=True):
     """
     Integrate the csc_matrix over its column axis in the specified range.
 

--- a/raysect/optical/material/emitter/regular_grid_utility.pyx
+++ b/raysect/optical/material/emitter/regular_grid_utility.pyx
@@ -1,0 +1,180 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2017, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Integration utilities for regular grid emitters.
+"""
+
+from scipy.sparse import csc_matrix
+from raysect.core.math.cython cimport find_index
+cimport cython
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.initializedcheck(False)
+cdef object integrate_contineous(double[::1] x, object y, double x0, double x1, bint extrapolate=True):
+    """
+    Integrate the csc_matrix over its column axis in the specified range.
+
+    :param double[::1] x: A memory view to a double array containing monotonically increasing
+        values.
+    :param csc_matrix y: A csc_matrix to integrate with the columns corresponding to
+        the x array points.
+    :param double x0: Start point of integration.
+    :param double x1: End point of integration.
+    :param bool extrapolate: If True, the values of y outside the provided range
+        will be equal to the values at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+
+        :return: Integrated csc_matrix (one-column csc_matrix).
+    """
+
+    cdef:
+        object integral_sum
+        double weight
+        int index, lower_index, upper_index, top_index, nvoxel
+
+    nvoxel = y.shape[0]
+
+    # invalid range
+    if x1 <= x0:
+        return csc_matrix((nvoxel, 1))
+
+    # identify array indices that lie between requested values
+    lower_index = find_index(x, x0) + 1
+    upper_index = find_index(x, x1)
+
+    # are both points below the bottom of the array?
+    if upper_index == -1:
+
+        if extrapolate:
+            # extrapolate from first array value (nearest-neighbour)
+            return y[:, 0] * (x1 - x0)
+        # return zero matrix if extrapolate is set to False
+        return csc_matrix((nvoxel, 1))
+
+    # are both points beyond the top of the array?
+    top_index = x.shape[0] - 1
+    if lower_index > top_index:
+
+        if extrapolate:
+            # extrapolate from last array value (nearest-neighbour)
+            return y[:, top_index] * (x1 - x0)
+        # return zero matrix if extrapolate is set to False
+        return csc_matrix((nvoxel, 1))
+
+    # numerically integrate array
+    if lower_index > upper_index:
+
+        # both values lie inside the same array segment
+        # the names lower_index and upper_index are now misnomers, they are swapped!
+        weight = (0.5 * (x1 + x0) - x[upper_index]) / (x[lower_index] - x[upper_index])
+
+        # trapezium rule integration
+        return (y[:, upper_index] + weight * (y[:, lower_index] - y[:, upper_index])) * (x1 - x0)
+
+    else:
+
+        integral_sum = csc_matrix((nvoxel, 1))
+
+        if lower_index == 0:
+
+            # add contribution from point below array
+            integral_sum += y[:, 0] * (x[0] - x0)
+
+        else:
+
+            # add lower range partial cell contribution
+            weight = (x0 - x[lower_index - 1]) / (x[lower_index] - x[lower_index - 1])
+
+            # trapezium rule integration
+            integral_sum += (0.5 * (x[lower_index] - x0)) * (y[:, lower_index - 1] + y[:, lower_index] +
+                                                             weight * (y[:, lower_index] - y[:, lower_index - 1]))
+
+        # sum up whole cell contributions
+        for index in range(lower_index, upper_index):
+
+            # trapezium rule integration
+            integral_sum += 0.5 * (y[:, index] + y[:, index + 1]) * (x[index + 1] - x[index])
+
+        if upper_index == top_index:
+
+            # add contribution from point above array
+            integral_sum += y[:, top_index] * (x1 - x[top_index])
+
+        else:
+
+            # add upper range partial cell contribution
+            weight = (x1 - x[upper_index]) / (x[upper_index + 1] - x[upper_index])
+
+            # trapezium rule integration
+            integral_sum += (0.5 * (x1 - x[upper_index])) * (2 * y[:, upper_index] + weight * (y[:, upper_index + 1] - y[:, upper_index]))
+
+        return integral_sum
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.initializedcheck(False)
+cdef object integrate_delta_function(double[::1] x, object y, double x0, double x1):
+    """
+    Integrate delta-function-like csc_matrix over its column axis in the specified range.
+
+    :param double[::1] x: A memory view to a double array containing monotonically increasing
+        values.
+    :param csc_matrix y: A delta-function-like csc_matrix to integrate with the columns
+        corresponding to the x array points.
+    :param double x0: Start point of integration.
+    :param double x1: End point of integration.
+
+    :return: Integrated csc_matrix (one-column csc_matrix).
+    """
+    cdef:
+        object integral_sum
+        int i, nvoxel, nspec
+
+    nvoxel = y.shape[0]
+    nspec = y.shape[1]
+
+    # invalid range
+    if x1 <= x0:
+        return csc_matrix((nvoxel, 1))
+
+    integral_sum = csc_matrix((nvoxel, 1))
+
+    for i in range(nspec):
+        if x0 <= x[i] < x1:
+            integral_sum += y[:, i]
+
+    return integral_sum

--- a/raysect/optical/material/emitter/regular_grid_utility.pyx
+++ b/raysect/optical/material/emitter/regular_grid_utility.pyx
@@ -62,7 +62,8 @@ cdef object integrate_contineous(double[::1] x, object y, double x0, double x1, 
     cdef:
         object integral_sum
         double weight
-        int index, lower_index, upper_index, top_index, nvoxel
+        int index, lower_index, upper_index, top_index
+        long nvoxel
 
     nvoxel = y.shape[0]
 
@@ -162,7 +163,8 @@ cdef object integrate_delta_function(double[::1] x, object y, double x0, double 
     """
     cdef:
         object integral_sum
-        int i, nvoxel, nspec
+        int i, nspec
+        long nvoxel
 
     nvoxel = y.shape[0]
     nspec = y.shape[1]

--- a/raysect/optical/material/emitter/regular_grid_volumes.py
+++ b/raysect/optical/material/emitter/regular_grid_volumes.py
@@ -86,7 +86,7 @@ class RegularGridCylinder(RegularGridVolume):
 
     :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
         emission defined on a regular :math:`(R, \phi, Z)` grid in :math:`W/(str\,m^3\,nm)`
-        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        (continuous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
         Spectral emission can be provided either for selected cells of the regular
         grid (2D array or sparse matrix) or for all grid cells (4D array).
         Note that if provided as a 2D array (or sparse matrix), the argument `grid_shape`
@@ -110,13 +110,13 @@ class RegularGridCylinder(RegularGridVolume):
     :param float step: The step of integration along the ray (in meters), defaults to
         `0.25*min((radius_outer - radius_inner) / n_r, height / n_z)`, where n_r and n_z are
         the grid resolutions in `R` and `Z` directions.
-    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :param bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
-        Defaults to `contineous=True`.
+        Defaults to `continuous=True`.
     :param bool extrapolate: If True, the emission outside the provided spectral range
         will be equal to the emission at the borders of this range (nearest-neighbour
         extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
-        This parameter is ignored if `contineous=False`.
+        This parameter is ignored if `continuous=False`.
     :param Node parent: Scene-graph parent node or None (default = None).
     :param AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
         relative to the scene-graph parent (default = identity matrix).
@@ -134,7 +134,7 @@ class RegularGridCylinder(RegularGridVolume):
         >>> from raysect.optical import World, translate, rotate
         >>> from raysect.primitive import Cylinder, Subtract
         >>> from raysect.optical.material import RegularGridCylinder
-        >>> ### Contineous case ###
+        >>> ### continuous case ###
         >>> # grid parameters
         >>> rmin = 0
         >>> rmax = 2.
@@ -197,7 +197,7 @@ class RegularGridCylinder(RegularGridVolume):
                                           height=zmax - zmin, radius_inner=rmin,
                                           period=phi_period, parent=world,
                                           transform = translate(0, 0, zmin),
-                                          contineous=False)
+                                          continuous=False)
         ...
         >>> camera.spectral_bins = 15
         >>> camera.min_wavelength = 457.
@@ -215,7 +215,7 @@ class RegularGridCylinder(RegularGridVolume):
     """
 
     def __init__(self, emission, wavelengths, radius_outer, height, radius_inner=0, period=360., grid_shape=None,
-                 step=None, contineous=True, extrapolate=True, parent=None, transform=None):
+                 step=None, continuous=True, extrapolate=True, parent=None, transform=None):
         if 360. % period > 1.e-3:
             raise ValueError("The period %.3f is not a multiple of 360." % period)
         if emission.ndim == 2:
@@ -237,7 +237,7 @@ class RegularGridCylinder(RegularGridVolume):
         dz = height / grid_shape[2]
         grid_steps = (dr, dphi, dz)
         step = step or 0.25 * min(dr, dz)
-        material = CylindricalRegularEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+        material = CylindricalRegularEmitter(grid_shape, grid_steps, emission, wavelengths, continuous=continuous, extrapolate=extrapolate,
                                              integrator=CylindricalRegularIntegrator(step), rmin=radius_inner)
         primitive = Subtract(Cylinder(radius_outer, height), Cylinder(radius_inner, height),
                              material=material, parent=parent, transform=transform)
@@ -251,7 +251,7 @@ class RegularGridBox(RegularGridVolume):
 
     :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
         emission defined on a regular :math:`(X, Y, Z)` grid in :math:`W/(str\,m^3\,nm)`
-        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        (continuous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
         Spectral emission can be provided either for selected cells of the regular
         grid (2D array or sparse matrix) or for all grid cells (4D array).
         Note that if provided as a 2D array (or sparse matrix), the argument `grid_shape`
@@ -271,13 +271,13 @@ class RegularGridBox(RegularGridVolume):
     :param float step: The step of integration along the ray (in meters), defaults to
         `step = 0.25 * min(xmax / n_x, ymax / n_y, zmax / n_z)`, where (n_x, n_y, n_z) is
         the grid resolution.
-    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+    :param bool continuous: Defines whether the emission is porvided as a continuous spectrum
         (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
-        Defaults to `contineous=True`.
+        Defaults to `continuous=True`.
     :param bool extrapolate: If True, the emission outside the provided spectral range
         will be equal to the emission at the borders of this range (nearest-neighbour
         extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
-        This parameter is ignored if `contineous=False`.
+        This parameter is ignored if `continuous=False`.
     :param Node parent: Scene-graph parent node or None (default = None).
     :param AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
         relative to the scene-graph parent (default = identity matrix).
@@ -354,7 +354,7 @@ class RegularGridBox(RegularGridVolume):
         >>> world = World()
         >>> pipeline = SpectralRadiancePipeline2D()
         >>> material = RegularGridBox(emission, wavelengths, xmax - xmin, ymax - ymin, zmax - zmin,
-                                      contineous=False, transform=translate(xmin, ymin, zmin),
+                                      continuous=False, transform=translate(xmin, ymin, zmin),
                                       parent=world)
         ...
         >>> camera.spectral_bins = 15
@@ -373,7 +373,7 @@ class RegularGridBox(RegularGridVolume):
     """
 
     def __init__(self, emission, wavelengths, xmax, ymax, zmax, grid_shape=None, step=None,
-                 contineous=True, extrapolate=True, parent=None, transform=None):
+                 continuous=True, extrapolate=True, parent=None, transform=None):
 
         if emission.ndim == 2:
             if grid_shape is None:
@@ -394,7 +394,7 @@ class RegularGridBox(RegularGridVolume):
         dz = zmax / grid_shape[2]
         grid_steps = (dx, dy, dz)
         step = step or 0.25 * min(dx, dy, dz)
-        material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=contineous,
+        material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths, continuous=continuous,
                                            extrapolate=extrapolate, integrator=CartesianRegularIntegrator(step))
         primitive = Box(lower=Point3D(0, 0, 0), upper=Point3D(xmax, ymax, zmax), material=material, parent=parent, transform=transform)
         super().__init__(primitive)

--- a/raysect/optical/material/emitter/regular_grid_volumes.py
+++ b/raysect/optical/material/emitter/regular_grid_volumes.py
@@ -1,0 +1,400 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2014-2017, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Regular Grid Volumes accelerate integration through inhomogeneous emitting volume
+as they use pre-calculated values of spectral emissivity on a regular grid.
+
+Use `RegularGridBox` class for Cartesian grids and `RegularGridCylinder` class for cylindrical
+grids (3D or axisymmetrical).
+"""
+
+from raysect.optical import Point3D
+from raysect.primitive import Cylinder, Subtract, Box
+from .regular_grid_emitters import CylindricalRegularIntegrator, CartesianRegularIntegrator
+from .regular_grid_emitters import CylindricalRegularEmitter, CartesianRegularEmitter
+
+
+class RegularGridVolume:
+    """
+    Basic class for regular grid volumes.
+
+    :ivar Node parent: Scene-graph parent node.
+    :ivar AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
+        relative to the scene-graph parent.
+    :ivar RegularGridEmitter material: RegularGridEmitter material.
+    """
+
+    def __init__(self, primitive):
+        self._primitive = primitive
+
+    @property
+    def parent(self):
+        return self._primitive.parent
+
+    @parent.setter
+    def parent(self, value):
+        self._primitive.parent = value
+
+    @property
+    def transform(self):
+        return self._primitive.transform
+
+    @transform.setter
+    def transform(self, value):
+        self._primitive.transform = value
+
+    @property
+    def material(self):
+        return self._primitive.material
+
+
+class RegularGridCylinder(RegularGridVolume):
+    """
+    Regular Grid Volume for cylindrical emitter defined on a regular 3D :math:`(R, \phi, Z)` grid.
+    The emitter is periodic in :math:`\phi` direction.
+    The base of the cylinder is located at `Z = 0` plane. Use `transform`
+    parameter to move it.
+
+    :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
+        emission defined on a regular :math:`(R, \phi, Z)` grid in :math:`W/(str\,m^3\,nm)`
+        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        Spectral emission can be provided either for selected cells of the regular
+        grid (2D array or sparse matrix) or for all grid cells (4D array).
+        Note that if provided as a 2D array (or sparse matrix), the argument `grid_shape`
+        must be provided and the spatial index `(ir, iphi, iz)` must be flattened in a row-major
+        order: `iflat = grid_shape[1] * grid_shape[2] * ir + grid_shape[2] * iphi + iz`.
+        Regardless of the form in which the emission is provided, the last axis is the
+        spectral one.  The emission will be stored as a сompressed sparse column matrix
+        (`scipy.sparse.csc_matrix`). To reduce memory consumption, provide it as a `csc_matrix`.
+    :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
+        provided emission array. The size of this array must be equal to `emission.shape[-1]`.
+        Initialisation will be faster if this array contains monotonically increasing values.
+    :param float radius_outer: Radius of the outer cylinder and the upper bound of grid in
+        `R` direction (in meters).
+    :param float height: Height of the cylinder and the length of grid in `Z` direction
+        (in meters).
+    :param float radius_inner: Radius of the inner cylinder and the lower bound of grid in
+        `R` direction (in meters), defaults to `radius_inner=0`.
+    :param float period: A period in :math:`\phi` direction (in degree), defaults to `period=360`.
+    :param tuple grid_shape: The number of grid cells along each direction,
+        defaults to `grid_shape=None`. Ignored if emission is a 4D array.
+    :param float step: The step of integration along the ray (in meters), defaults to
+        `0.25*min((radius_outer - radius_inner) / n_r, height / n_z)`, where n_r and n_z are
+        the grid resolutions in `R` and `Z` directions.
+    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+        Defaults to `contineous=True`.
+    :param bool extrapolate: If True, the emission outside the provided spectral range
+        will be equal to the emission at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+        This parameter is ignored if `contineous=False`.
+    :param Node parent: Scene-graph parent node or None (default = None).
+    :param AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
+        relative to the scene-graph parent (default = identity matrix).
+
+    :ivar Node parent: Scene-graph parent node.
+    :ivar AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
+        relative to the scene-graph parent.
+    :ivar CylindricalRegularmitter material: CylindricalRegularEmitter material.
+
+    Continoues spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, rotate
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import RegularGridCylinder
+        >>> ### Contineous case ###
+        >>> # grid parameters
+        >>> rmin = 0
+        >>> rmax = 2.
+        >>> zmin = -0.25
+        >>> zmax = 0.25
+        >>> r, dr = np.linspace(rmin, rmax, 201, retstep=True)
+        >>> r = r[:-1] + 0.5 * dr  # moving to the grid cell centers
+        >>> integration_step = 0.05
+        >>> # spectral emission profile
+        >>> min_wavelength = 375.
+        >>> max_wavelength = 740.
+        >>> wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, 50,
+                                                        retstep=True)
+        >>> wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+        >>> wvl_range = min_wavelength - max_wavelength
+        >>> shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+        >>> emission = np.cos(shift[None, None, None, :] * radius[:, None, None, None])**4
+        >>> # scene
+        >>> world = World()
+        >>> emitter = RegularGridCylinder(emission, wavelengths, radius_outer=rmax,
+                                          height=zmax - zmin, radius_inner=rmin,
+                                          period=phi_period, parent=world)
+        >>> emitter.material.transform = translate(-rmax, -rmax + 1., zmin) * rotate(30, 0, 0)
+        ...
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                         camera.spectral_bins)
+
+    Discrete spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate
+        >>> from raysect.optical.observer import SpectralRadiancePipeline2D
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import RegularGridCylinder
+        >>> # Assume that the files 'Be_4574A.npy' and 'Be_527A.npy' contain the emissions
+        >>> # (in W / m^3) of Be I (3d1 1D2 -> 2p1 1P1) and Be II (4s1 2S0.5 -> 3p1 2P2.5)
+        >>> # spectral lines defined on a regular cylindrical grid: 3.5 m < R < 9 m,
+        >>> # 0 < phi < 20 deg, -5 m < Z < 5 m, and periodic in phi direction.
+        >>> emission_4574 = np.load('Be_4574A.npy')
+        >>> emission_5272 = np.load('Be_5272A.npy')
+        >>> wavelengths = np.array([457.4, 527.2])
+        >>> # Grid properties
+        >>> rmin = 3.5
+        >>> rmax = 9.
+        >>> phi_period = 20.
+        >>> zmin = -5.
+        >>> zmax = 5.
+        >>> grid_shape = emission_4574.shape
+        >>> emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], 2))
+        >>> emission[:, :, :, 0] = emission_4574 / (4. * np.pi)  # to W/(m^3 str)
+        >>> emission[:, :, :, 1] = emission_5272 / (4. * np.pi)
+        >>> # Creating the scene
+        >>> world = World()
+        >>> pipeline = SpectralRadiancePipeline2D()
+        >>> emitter = RegularGridCylinder(emission, wavelengths, radius_outer=rmax,
+                                          height=zmax - zmin, radius_inner=rmin,
+                                          period=phi_period, parent=world,
+                                          transform = translate(0, 0, zmin),
+                                          contineous=False)
+        ...
+        >>> camera.spectral_bins = 15
+        >>> camera.min_wavelength = 457.
+        >>> camera.max_wavelength = 528.
+        >>> delta_wavelength = (camera.max_wavelength - camera.min_wavelength)/camera.spectral_bins
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                         camera.spectral_bins)
+        ...
+        >>> # If reflections do not change the wavelength, the results for each spectral line
+        >>> # can be obtained in W/(m^2 str) in the following way.
+        >>> radiance_4574 = pipeline.frame.mean[:, :, 0] * delta_wavelength
+        >>> radiance_5272 = pipeline.frame.mean[:, :, -1] * delta_wavelength
+    """
+
+    def __init__(self, emission, wavelengths, radius_outer, height, radius_inner=0, period=360., grid_shape=None,
+                 step=None, contineous=True, extrapolate=True, parent=None, transform=None):
+        if 360. % period > 1.e-3:
+            raise ValueError("The period %.3f is not a multiple of 360." % period)
+        if emission.ndim == 2:
+            if grid_shape is None:
+                raise ValueError("If 'emission' is a 2D array, 'grid_shape' parameter must be specified.")
+            if len(grid_shape) != 3:
+                raise ValueError("Argument 'grid_shape' must contain 3 elements.")
+            if grid_shape[0] <= 0 or grid_shape[1] <= 0 or grid_shape[2] <= 0:
+                raise ValueError('Grid sizes must be > 0.')
+
+        elif emission.ndim == 4:
+            grid_shape = (emission.shape[0], emission.shape[1], emission.shape[2])
+
+        else:
+            raise ValueError("Argument 'emission' must be a 4D or 2D array.")
+
+        dr = (radius_outer - radius_inner) / grid_shape[0]
+        dphi = period / grid_shape[1]
+        dz = height / grid_shape[2]
+        grid_steps = (dr, dphi, dz)
+        step = step or 0.25 * min(dr, dz)
+        material = CylindricalRegularEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=contineous, extrapolate=extrapolate,
+                                             integrator=CylindricalRegularIntegrator(step), rmin=radius_inner)
+        primitive = Subtract(Cylinder(radius_outer, height), Cylinder(radius_inner, height),
+                             material=material, parent=parent, transform=transform)
+        super().__init__(primitive)
+
+
+class RegularGridBox(RegularGridVolume):
+    """
+    Regular Grid Volume for rectangular emitter defined on a regular 3D :math:`(X, Y, Z)` grid.
+    The grid starts at (0, 0, 0). Use `transform` parameter to move it.
+
+    :param object ~.emission: The 2D or 4D array or scipy sparse matrix containing the
+        emission defined on a regular :math:`(X, Y, Z)` grid in :math:`W/(str\,m^3\,nm)`
+        (contineous spectrum) or in :math:`W/(str\,m^3)` (discrete spectrum).
+        Spectral emission can be provided either for selected cells of the regular
+        grid (2D array or sparse matrix) or for all grid cells (4D array).
+        Note that if provided as a 2D array (or sparse matrix), the argument `grid_shape`
+        must be provided and the spatial index `(ix, iy, iz)` must be flattened in a row-major
+        order: `iflat = grid_shape[1] * grid_shape[2] * ix + grid_shape[2] * iy + iz`.
+        Regardless of the form in which the emission is provided, the last axis is the
+        spectral one.  The emission will be stored as a сompressed sparse column matrix
+        (`scipy.sparse.csc_matrix`). To reduce memory consumption, provide it as a `csc_matrix`.
+    :param ndarray wavelengths: The 1D array of wavelengths corresponding to the last axis of
+        provided emission array. The size of this array must be equal to `emission.shape[-1]`.
+        Initialisation will be faster if this array contains monotonically increasing values.
+    :param float xmax: Upper bound of grid in `X` direction (in meters).
+    :param float ymax: Upper bound of grid in `Y` direction (in meters).
+    :param float zmax: Upper bound of grid in `Z` direction (in meters).
+    :param tuple grid_shape: The number of grid cells along each direction,
+        defaults to `grid_shape=None`. Ignored if emission is a 4D array.
+    :param float step: The step of integration along the ray (in meters), defaults to
+        `step = 0.25 * min(xmax / n_x, ymax / n_y, zmax / n_z)`, where (n_x, n_y, n_z) is
+        the grid resolution.
+    :param bool contineous: Defines whether the emission is porvided as a contineous spectrum
+        (in :math:`W/(str\,m^3\,nm)`) or as a discrete spectrum (in :math:`W/(str\,m^3)`).
+        Defaults to `contineous=True`.
+    :param bool extrapolate: If True, the emission outside the provided spectral range
+        will be equal to the emission at the borders of this range (nearest-neighbour
+        extrapolation), otherwise it will be zero. Defaults to `extrapolate=True`.
+        This parameter is ignored if `contineous=False`.
+    :param Node parent: Scene-graph parent node or None (default = None).
+    :param AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
+        relative to the scene-graph parent (default = identity matrix).
+
+    :ivar Node parent: Scene-graph parent node.
+    :ivar AffineMatrix3D transform: An AffineMatrix3D defining the local co-ordinate system
+        relative to the scene-graph parent.
+    :ivar CartesianRegularEmitter material: CartesianRegularEmitter material.
+
+    Continoues spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, rotate
+        >>> from raysect.primitive import Cylinder, Subtract
+        >>> from raysect.optical.material import RegularGridBox
+        >>> # grid parameters
+        >>> xmin = ymin = -1.
+        >>> xmax = ymax = 1.
+        >>> zmin = -0.25
+        >>> zmax = 0.25
+        >>> x, dx = np.linspace(xmin, xmax, 101, retstep=True)
+        >>> y, dy = np.linspace(ymin, ymax, 101, retstep=True)
+        >>> x = x[:-1] + 0.5 * dx  # moving to the grid cell centers
+        >>> y = y[:-1] + 0.5 * dy
+        >>> # spectral emission profile
+        >>> min_wavelength = 375.
+        >>> max_wavelength = 740.
+        >>> wavelengths, delta_wavelength = np.linspace(min_wavelength, max_wavelength, 50,
+                                                        retstep=True)
+        >>> wvl_centre = 0.5 * (max_wavelength + min_wavelength)
+        >>> wvl_range = min_wavelength - max_wavelength
+        >>> shift = 2 * (wavelengths - wvl_centre) / wvl_range + 5.
+        >>> radius = np.sqrt((x * x)[:, None] + (y * y)[None, :])
+        >>> emission = np.cos(shift[None, None, None, :] * radius[:, :, None, None])**4
+        >>> # scene
+        >>> world = World()
+        >>> emitter = RegularGridBox(emission, wavelengths, xmax - xmin, ymax - ymin, zmax - zmin,
+                                     parent=world)
+        >>> emitter.material.transform = (translate(0, 1., 0) * rotate(30, 0, 0) *
+                                          translate(xmin, ymin, zmin))
+        ...
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> emitter.material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                         camera.spectral_bins)
+
+    Discrete spectrum example:
+
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from raysect.optical import World, translate, Point3D
+        >>> from raysect.primitive import Box
+        >>> from raysect.optical.observer import SpectralRadiancePipeline2D
+        >>> from raysect.optical.material import RegularGridBox
+        >>> # Assume that the files 'Be_4574A.npy' and 'Be_527A.npy' contain the emissions
+        >>> # (in W / m^3) of Be I (3d1 1D2 -> 2p1 1P1) and Be II (4s1 2S0.5 -> 3p1 2P2.5)
+        >>> # spectral lines defined on a regular Cartesian grid: -3 m < X < 3 m,
+        >>> # -3 m < Y < 3 m and -6 m < Z < 6 m.
+        >>> emission_4574 = np.load('Be_4574A.npy')
+        >>> emission_5272 = np.load('Be_5272A.npy')
+        >>> # Grid properties
+        >>> xmin = ymin = -3.
+        >>> xmax = ymax = 3.
+        >>> zmin = -6.
+        >>> zmax = 6.
+        >>> grid_shape = emission_4574.shape
+        >>> emission = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], 2))
+        >>> emission[:, :, :, 0] = emission_4574 / (4. * np.pi)  # to W/(m^3 str)
+        >>> emission[:, :, :, 1] = emission_5272 / (4. * np.pi)
+        >>> # Creating the scene
+        >>> world = World()
+        >>> pipeline = SpectralRadiancePipeline2D()
+        >>> material = RegularGridBox(emission, wavelengths, xmax - xmin, ymax - ymin, zmax - zmin,
+                                      contineous=False, transform=translate(xmin, ymin, zmin),
+                                      parent=world)
+        ...
+        >>> camera.spectral_bins = 15
+        >>> camera.min_wavelength = 457
+        >>> camera.max_wavelength = 528
+        >>> delta_wavelength = (camera.max_wavelength - camera.min_wavelength)/camera.spectral_bins
+        >>> # if ray spectral properties do not change during the rendering,
+        >>> # build the cache before the first camera.observe() call to reduce memory consumptions
+        >>> material.cache_build(camera.min_wavelength, camera.max_wavelength,
+                                 camera.spectral_bins)
+        ...
+        >>> # If reflections do not change the wavelength, the results for each spectral line
+        >>> # can be obtained in W/(m^2 sr) in the following way.
+        >>> radiance_4574 = pipeline.frame.mean[:, :, 0] * delta_wavelength
+        >>> radiance_5272 = pipeline.frame.mean[:, :, -1] * delta_wavelength
+    """
+
+    def __init__(self, emission, wavelengths, xmax, ymax, zmax, grid_shape=None, step=None,
+                 contineous=True, extrapolate=True, parent=None, transform=None):
+
+        if emission.ndim == 2:
+            if grid_shape is None:
+                raise ValueError("If 'emission' is a 2D array, 'grid_shape' parameter must be specified.")
+            if len(grid_shape) != 3:
+                raise ValueError("Argument 'grid_shape' must contain 3 elements.")
+            if grid_shape[0] <= 0 or grid_shape[1] <= 0 or grid_shape[2] <= 0:
+                raise ValueError('Grid sizes must be > 0.')
+
+        elif emission.ndim == 4:
+            grid_shape = (emission.shape[0], emission.shape[1], emission.shape[2])
+
+        else:
+            raise ValueError("Argument 'emission' must be a 4D or 2D array.")
+
+        dx = xmax / grid_shape[0]
+        dy = ymax / grid_shape[1]
+        dz = zmax / grid_shape[2]
+        grid_steps = (dx, dy, dz)
+        step = step or 0.25 * min(dx, dy, dz)
+        material = CartesianRegularEmitter(grid_shape, grid_steps, emission, wavelengths, contineous=contineous,
+                                           extrapolate=extrapolate, integrator=CartesianRegularIntegrator(step))
+        primitive = Box(lower=Point3D(0, 0, 0), upper=Point3D(xmax, ymax, zmax), material=material, parent=parent, transform=transform)
+        super().__init__(primitive)

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "Topic :: Multimedia :: Graphics :: 3D Rendering",
         "Topic :: Scientific/Engineering :: Physics"
     ],
-    install_requires=['numpy', 'cython>=0.28', 'matplotlib'],
+    install_requires=['numpy', 'scipy', 'cython>=0.28', 'matplotlib'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe= False,


### PR DESCRIPTION
This is a draft pull request for fast emitters and integrators that work with regular grids, It was originally proposed for Cherab ([issue #204](https://github.com/cherab/core/issues/204)) but, as @CnlPepper suggested, these emitters and integrators are more suitable for Raysect.

I tried to address all the issues raised in [the discussion](https://github.com/cherab/core/issues/204). 

The emitters work as follows:

- The emission can be provided as a 4D array, 2D array or scipy sparse matrix along with array of wavelengths for which this emission is specified. The units are: W / (m^3 str nm) for continuous spectrum and W / (m^3 str) for discrete spectrum (spectral lines). The user specifies the type of spectrum with `continuous` argument, which is `True` by default. `RegularGridEmitter` stores the emission as a compressed sparse column-major matrix ([scipy.sparse.csc_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html)) for fast column access required for resampling.
- Similar to `SpectralFunction`, the `RegularGridEmitter` automatically rebuilds the cache when the existing cache is not match the ray spectral properties. The cache validity is checked each time the `emission_function()` or `RegularGridIntegrator.integrate()` is called. The cache is stored as a compressed sparse row-major matrix ([scipy.sparse.csr_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html)) for fast row access required for volume integration. If `continuous=True`, the resampling is performed the same way as in `InterpoatedSF`, but with optional extrapolation. If `continuous=False`, the spectrum is not interpolated, instead the emission at each spectral bin sums the emissions at all spectral lines that fall into that bin, divided by the bin's width. Thus, the cache always contain the emission in W / (m^3 str nm).
- Since `RegularGridEmitter` is designed to work with very large grids, it has a few memory-saving options.
    1. If the emission is provided in float32, the cache will be also stored in float32. Also, the user has an option to store the cache in float32 even if the emission is in float64.
    2. In multi-process rendering, each process creates it's own cache. This looks like a correct behaviour, but can easily "eat" all available memory. To prevent this from happening, the user can preset the cache with `cache_build(min_wavelength, max_wavelength, bins)` function before `camera.observe()` is called. All processes will use this cache as long as it remains valid (of course building the cache in advance is useless in dispersive rendering).
    3. The user has an option to override the cache with `cache_override(new_cache, min_wavelength, max_wavelength)`, so if there is not enough memory to store both the original emission and the cache, the user can provide the cache only by initialising the emitter with an empty csc_matrix and then calling  `cache_override()`. Again, this will not work in case of dispersive rendering.
- The cache is directly accessible from C-interface through read-only memoryviews. All functions that control the cache are accessible in both Python and C.

Currently, building the cache is slow, and it's noticeable for large grids. I'll try to optimise it in the future.

This draft pull request contains 4 demos. The first one is a kind of tutorial.
The code has built-in documentation but I didn't update the .rst files yet. Please look through the code, and if it's OK in general, I'll update the documentation and make this PR ready for review.

Also, I have a question to @CnlPepper. The `SpectralFunction` has custom `__getstate__()`, `__setstate__()`, `__reduce__()` methods. Do I need them in `RegularGridEmitter` too?