### PR TITLE
Feature/quaternion improvements

### DIFF
--- a/raysect/core/math/__init__.pxd
+++ b/raysect/core/math/__init__.pxd
@@ -33,7 +33,7 @@ from raysect.core.math.point cimport Point3D, Point2D, new_point3d, new_point2d
 from raysect.core.math.vector cimport Vector2D, new_vector2d, Vector3D, new_vector3d
 from raysect.core.math.normal cimport Normal3D, new_normal3d
 from raysect.core.math.affinematrix cimport AffineMatrix3D, new_affinematrix3d
-from raysect.core.math.quaternion cimport Quaternion, new_quaternion
+from raysect.core.math.quaternion cimport Quaternion, new_quaternion, rotation_delta
 from raysect.core.math.transform cimport translate, rotate_x, rotate_y, rotate_z, rotate_vector, rotate, rotate_basis, to_cylindrical, from_cylindrical
 from raysect.core.math.units cimport *
 from raysect.core.math.statsarray cimport StatsBin, StatsArray1D, StatsArray2D, StatsArray3D

--- a/raysect/core/math/__init__.pxd
+++ b/raysect/core/math/__init__.pxd
@@ -33,7 +33,7 @@ from raysect.core.math.point cimport Point3D, Point2D, new_point3d, new_point2d
 from raysect.core.math.vector cimport Vector2D, new_vector2d, Vector3D, new_vector3d
 from raysect.core.math.normal cimport Normal3D, new_normal3d
 from raysect.core.math.affinematrix cimport AffineMatrix3D, new_affinematrix3d
-from raysect.core.math.quaternion cimport Quaternion, new_quaternion, rotation_delta
+from raysect.core.math.quaternion cimport Quaternion, new_quaternion
 from raysect.core.math.transform cimport translate, rotate_x, rotate_y, rotate_z, rotate_vector, rotate, rotate_basis, to_cylindrical, from_cylindrical
 from raysect.core.math.units cimport *
 from raysect.core.math.statsarray cimport StatsBin, StatsArray1D, StatsArray2D, StatsArray3D

--- a/raysect/core/math/__init__.py
+++ b/raysect/core/math/__init__.py
@@ -33,7 +33,7 @@ from .point import Point2D, Point3D
 from .vector import Vector2D, Vector3D
 from .normal import Normal3D
 from .affinematrix import AffineMatrix3D
-from .quaternion import Quaternion, rotation_delta
+from .quaternion import Quaternion
 from .transform import translate, rotate_x, rotate_y, rotate_z, rotate_vector, rotate, rotate_basis, to_cylindrical, from_cylindrical
 from .units import *
 from .statsarray import StatsBin, StatsArray1D, StatsArray2D, StatsArray3D

--- a/raysect/core/math/__init__.py
+++ b/raysect/core/math/__init__.py
@@ -33,7 +33,7 @@ from .point import Point2D, Point3D
 from .vector import Vector2D, Vector3D
 from .normal import Normal3D
 from .affinematrix import AffineMatrix3D
-from .quaternion import Quaternion
+from .quaternion import Quaternion, rotation_delta
 from .transform import translate, rotate_x, rotate_y, rotate_z, rotate_vector, rotate, rotate_basis, to_cylindrical, from_cylindrical
 from .units import *
 from .statsarray import StatsBin, StatsArray1D, StatsArray2D, StatsArray3D

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -64,15 +64,17 @@ cdef class Quaternion:
 
     cpdef bint is_unit(self, double tolerance=*)
 
-    cdef Vector3D get_axis(self, double tolerance=*)
+    cdef Vector3D get_axis(self)
 
     cdef double get_angle(self)
 
-    cpdef tuple to_euler_angles(self, str ordering=*)
+    # cpdef tuple to_euler_angles(self, str ordering=*)
+
+    cpdef Quaternion transform(self, AffineMatrix3D m)
 
     cpdef Quaternion copy(self)
 
-    cpdef Vector3D transform_vector(self, _Vec3 vector)
+    # cpdef Vector3D transform_vector(self, _Vec3 vector)
 
     cpdef AffineMatrix3D to_matrix(self)
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -65,6 +65,8 @@ cdef class Quaternion:
 
     cdef double get_angle(self)
 
+    cpdef tuple to_euler_angles(self, str ordering=*)
+
     cpdef Quaternion copy(self)
 
     cpdef Vector3D transform(self, _Vec3 vector)

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -51,7 +51,7 @@ cdef class Quaternion:
 
     cpdef AffineMatrix3D as_matrix(self)
 
-    cpdef Quaternion rotation_to(self, Quaternion q)
+    cpdef Quaternion quaternion_to(self, Quaternion q)
 
     cdef Quaternion neg(self)
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -37,23 +37,7 @@ cdef class Quaternion:
 
     cdef public double x, y, z, s
 
-    cdef double get_length(self) nogil
-
-    cdef object set_length(self, double value)
-
-    cdef Quaternion neg(self)
-
-    cdef Quaternion add(self, Quaternion q2)
-
-    cdef Quaternion sub(self, Quaternion q2)
-
-    cdef Quaternion mul_quaternion(self, Quaternion q2)
-
-    cdef Quaternion mul_scalar(self, double d)
-
-    cdef Quaternion div_quaternion(self, Quaternion q2)
-
-    cdef Quaternion div_scalar(self, double d)
+    cpdef Quaternion copy(self)
 
     cpdef Quaternion conjugate(self)
 
@@ -63,22 +47,33 @@ cdef class Quaternion:
 
     cpdef bint is_unit(self, double tolerance=*)
 
+    cpdef Quaternion transform(self, AffineMatrix3D m)
+
+    cpdef AffineMatrix3D as_matrix(self)
+
+    cpdef Quaternion rotation_to(self, Quaternion q)
+
+    cdef Quaternion neg(self)
+
+    cdef Quaternion add(self, Quaternion q)
+
+    cdef Quaternion sub(self, Quaternion q)
+
+    cdef Quaternion mul_quaternion(self, Quaternion q)
+
+    cdef Quaternion mul_scalar(self, double d)
+
+    cdef Quaternion div_quaternion(self, Quaternion q)
+
+    cdef Quaternion div_scalar(self, double d)
+
     cdef Vector3D get_axis(self)
 
     cdef double get_angle(self)
 
-    # cpdef tuple to_euler_angles(self, str ordering=*)
+    cdef double get_length(self) nogil
 
-    cpdef Quaternion transform(self, AffineMatrix3D m)
-
-    cpdef Quaternion copy(self)
-
-    # cpdef Vector3D transform_vector(self, _Vec3 vector)
-
-    cpdef AffineMatrix3D to_matrix(self)
-
-
-# cpdef Quaternion rotation_delta(Vector3D omega, double delta_t)
+    cdef object set_length(self, double v)
 
 
 cdef inline Quaternion new_quaternion(double x, double y, double z, double s):
@@ -91,9 +86,9 @@ cdef inline Quaternion new_quaternion(double x, double y, double z, double s):
 
     cdef Quaternion q
     q = Quaternion.__new__(Quaternion)
-    q.s = s
     q.x = x
     q.y = y
     q.z = z
+    q.s = s
     return q
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -69,7 +69,7 @@ cdef class Quaternion:
 
     cpdef Quaternion copy(self)
 
-    cpdef Vector3D transform(self, _Vec3 vector)
+    cpdef Vector3D transform_vector(self, _Vec3 vector)
 
     cpdef AffineMatrix3D to_matrix(self)
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -29,7 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math._vec3 cimport _Vec3
 from raysect.core.math.vector cimport Vector3D
 from raysect.core.math.affinematrix cimport AffineMatrix3D
 
@@ -79,7 +78,7 @@ cdef class Quaternion:
     cpdef AffineMatrix3D to_matrix(self)
 
 
-cpdef Quaternion rotation_delta(Vector3D omega, double delta_t)
+# cpdef Quaternion rotation_delta(Vector3D omega, double delta_t)
 
 
 cdef inline Quaternion new_quaternion(double x, double y, double z, double s):

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -74,6 +74,9 @@ cdef class Quaternion:
     cpdef AffineMatrix3D to_matrix(self)
 
 
+cpdef Quaternion rotation_delta(Vector3D omega, double delta_t)
+
+
 cdef inline Quaternion new_quaternion(double x, double y, double z, double s):
     """
     Quaternion factory function.

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -59,6 +59,8 @@ cdef class Quaternion:
 
     cpdef Quaternion normalise(self)
 
+    cpdef bint is_unit(self, double tolerance=*)
+
     cpdef Quaternion copy(self)
 
     cpdef Vector3D transform(self, _Vec3 vector)

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -28,9 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.affinematrix cimport AffineMatrix3D
-
+from raysect.core.math._vec3 cimport _Vec3
 from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.affinematrix cimport AffineMatrix3D
 
 
 cdef class Quaternion:
@@ -60,6 +60,8 @@ cdef class Quaternion:
     cpdef Quaternion normalise(self)
 
     cpdef Quaternion copy(self)
+
+    cpdef Vector3D transform(self, _Vec3 vector)
 
     cpdef AffineMatrix3D to_matrix(self)
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3
 
 # Copyright (c) 2014-2018, Dr Alex Meakins, Raysect Project
 # All rights reserved.
@@ -37,25 +38,27 @@ cdef class Quaternion:
 
     cdef public double x, y, z, s
 
+    cdef double get_length(self) nogil
+
+    cdef object set_length(self, double value)
+
     cdef Quaternion neg(self)
 
     cdef Quaternion add(self, Quaternion q2)
 
     cdef Quaternion sub(self, Quaternion q2)
 
-    cdef Quaternion mul(self, Quaternion q2)
+    cdef Quaternion mul_quaternion(self, Quaternion q2)
 
     cdef Quaternion mul_scalar(self, double d)
+
+    cdef Quaternion div_quaternion(self, Quaternion q2)
+
+    cdef Quaternion div_scalar(self, double d)
 
     cpdef Quaternion conjugate(self)
 
     cpdef Quaternion inverse(self)
-
-    cpdef double norm(self)
-
-    cdef Quaternion div(self, Quaternion q2)
-
-    cdef Quaternion div_scalar(self, double d)
 
     cpdef Quaternion normalise(self)
 

--- a/raysect/core/math/quaternion.pxd
+++ b/raysect/core/math/quaternion.pxd
@@ -61,6 +61,10 @@ cdef class Quaternion:
 
     cpdef bint is_unit(self, double tolerance=*)
 
+    cdef Vector3D get_axis(self, double tolerance=*)
+
+    cdef double get_angle(self)
+
     cpdef Quaternion copy(self)
 
     cpdef Vector3D transform(self, _Vec3 vector)

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -661,3 +661,38 @@ cdef class Quaternion:
         qs = cos(theta_2)
 
         return new_quaternion(qx, qy, qz, qs)
+
+
+cpdef Quaternion rotation_delta(Vector3D omega, double delta_t):
+    """
+    Calculates the quaternion representing a change in orientation for a given
+    angular velocity and time interval dt.
+
+    :param Vector3D omega: the angular velocity vector (degrees per second)
+    :param float delta_dt: the time increment dt over which the orientation
+    """
+
+    cdef:
+        double norm, sin_norm
+        Vector3D omega_rad, half_angle
+        Quaternion q, identity
+
+    omega_rad = new_vector3d(omega.x * DEG2RAD, omega.y * DEG2RAD, omega.z * DEG2RAD)
+    half_angle = omega_rad.mul(delta_t * 0.5)
+
+    norm = half_angle.get_length()
+
+    if norm > 0:
+
+        sin_norm = sin(norm) / norm
+
+        q = new_quaternion(half_angle.x * sin_norm,
+                           half_angle.y * sin_norm,
+                           half_angle.z * sin_norm,
+                           cos(norm))
+        q = q.normalise()
+
+    else:
+        q = new_quaternion(0, 0, 0, 1)
+
+    return q

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -95,7 +95,7 @@ cdef class Quaternion:
         elif i == 3:
             self.s = value
         else:
-            raise IndexError("Index out of range [0, 3].")
+            raise IndexError('Index out of range [0, 3].')
 
     def __iter__(self):
         """Iterates over the quaternion coordinates (x, y, z, s)
@@ -146,7 +146,7 @@ cdef class Quaternion:
             return q1.x == q2.x and q1.y == q2.y and q1.z == q2.z and q1.s == q2.s
 
         else:
-            raise TypeError("A quaternion can only be equality tested against another quaternion.")
+            raise TypeError('A quaternion can only be equality tested against another quaternion.')
 
     def __add__(object x, object y):
         """
@@ -253,7 +253,7 @@ cdef class Quaternion:
 
         else:
 
-            raise TypeError("Unsupported operand type. Expects a real number.")
+            raise TypeError('Unsupported operand type. Expects a real number.')
 
     cdef Quaternion neg(self):
         """
@@ -320,7 +320,7 @@ cdef class Quaternion:
 
         # prevent divide by zero
         if d == 0.0:
-            raise ZeroDivisionError("Cannot divide a quaternion by a zero scalar.")
+            raise ZeroDivisionError('Cannot divide a quaternion by a zero scalar.')
 
         d = 1.0 / d
         return new_quaternion(d * self.x, d * self.y, d * self.z, d * self.s)
@@ -392,7 +392,7 @@ cdef class Quaternion:
         # if current length is zero, problem is ill defined
         t = self.x * self.x + self.y * self.y + self.z * self.z + self.s * self.s
         if t == 0.0:
-            raise ZeroDivisionError("A zero length quaternion cannot be rescaled.")
+            raise ZeroDivisionError('A zero length quaternion cannot be rescaled.')
 
         # normalise and rescale quaternion
         t = v / sqrt(t)
@@ -420,7 +420,7 @@ cdef class Quaternion:
         # if current length is zero, problem is ill defined
         n = self.get_length()
         if n == 0.0:
-            raise ZeroDivisionError("A zero length quaternion cannot be normalised.")
+            raise ZeroDivisionError('A zero length quaternion cannot be normalised.')
 
         # normalise and rescale quaternion
         n = 1.0 / n
@@ -465,7 +465,7 @@ cdef class Quaternion:
         return 2 * acos(q.s) * RAD2DEG
 
     # todo: implement matrix to angle
-    # cpdef tuple to_euler_angles(self, str ordering="-Y-XZ"):
+    # cpdef tuple to_euler_angles(self, str ordering='-Y-XZ'):
     #     """Decomposes this quaternion into intrinsic euler angles based on the specified ordering."""
     #
     #     cdef:
@@ -477,7 +477,7 @@ cdef class Quaternion:
     #
     #     q = self.normalise()
     #
-    #     if ordering == "ZYX":
+    #     if ordering == 'ZYX':
     #         # roll (x''-axis rotation)
     #         sinroll_cospitch = 2 * (q.s * q.x + q.y * q.z)
     #         cosroll_cospitch = 1 - 2 * (q.x * q.x + q.y * q.y)
@@ -496,7 +496,7 @@ cdef class Quaternion:
     #         psi = atan2(sinyaw_cospitch, cosyaw_cospitch) * RAD2DEG
     #
     #     else:
-    #         raise ValueError("Unrecognised / unsupported euler angle decomposition ordering.")
+    #         raise ValueError('Unrecognised / unsupported euler angle decomposition ordering.')
     #
     #     return phi, theta, psi
 
@@ -681,7 +681,7 @@ cdef class Quaternion:
         """
 
         if not -180 <= angle <= 180:
-            raise ValueError("The angle of rotation must be in the range (-180, 180).")
+            raise ValueError('The angle of rotation must be in the range (-180, 180).')
 
         axis = axis.normalise()
         theta_2 = angle * DEG2RAD / 2

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -694,36 +694,36 @@ cdef class Quaternion:
         return new_quaternion(qx, qy, qz, qs)
 
 
-cpdef Quaternion rotation_delta(Vector3D omega, double delta_t):
-    """
-    Calculates the quaternion representing a change in orientation for a given
-    angular velocity and time interval dt.
-
-    :param Vector3D omega: the angular velocity vector (degrees per second)
-    :param float delta_dt: the time increment dt over which the orientation
-    """
-
-    cdef:
-        double norm, sin_norm
-        Vector3D omega_rad, half_angle
-        Quaternion q, identity
-
-    omega_rad = new_vector3d(omega.x * DEG2RAD, omega.y * DEG2RAD, omega.z * DEG2RAD)
-    half_angle = omega_rad.mul(delta_t * 0.5)
-
-    norm = half_angle.get_length()
-
-    if norm > 0:
-
-        sin_norm = sin(norm) / norm
-
-        q = new_quaternion(half_angle.x * sin_norm,
-                           half_angle.y * sin_norm,
-                           half_angle.z * sin_norm,
-                           cos(norm))
-        q = q.normalise()
-
-    else:
-        q = new_quaternion(0, 0, 0, 1)
-
-    return q
+# cpdef Quaternion rotation_delta(Vector3D omega, double delta_t):
+#     """
+#     Calculates the quaternion representing a change in orientation for a given
+#     angular velocity and time interval dt.
+#
+#     :param Vector3D omega: the angular velocity vector (degrees per second)
+#     :param float delta_dt: the time increment dt over which the orientation
+#     """
+#
+#     cdef:
+#         double norm, sin_norm
+#         Vector3D omega_rad, half_angle
+#         Quaternion q, identity
+#
+#     omega_rad = new_vector3d(omega.x * DEG2RAD, omega.y * DEG2RAD, omega.z * DEG2RAD)
+#     half_angle = omega_rad.mul(delta_t * 0.5)
+#
+#     norm = half_angle.get_length()
+#
+#     if norm > 0:
+#
+#         sin_norm = sin(norm) / norm
+#
+#         q = new_quaternion(half_angle.x * sin_norm,
+#                            half_angle.y * sin_norm,
+#                            half_angle.z * sin_norm,
+#                            cos(norm))
+#         q = q.normalise()
+#
+#     else:
+#         q = new_quaternion(0, 0, 0, 1)
+#
+#     return q

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -489,7 +489,7 @@ cdef class Quaternion:
 
         return new_quaternion(self.x, self.y, self.z, self.s)
 
-    cpdef Vector3D transform(self, _Vec3 vector):
+    cpdef Vector3D transform_vector(self, _Vec3 vector):
         """
         Rotates a supplied vector by the rotation specified in this quaternion.
         

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -30,7 +30,7 @@
 
 import numbers
 cimport cython
-from libc.math cimport sqrt, sin, cos
+from libc.math cimport sqrt, sin, cos, fabs
 
 from raysect.core.math.vector cimport new_vector3d
 from raysect.core.math.affinematrix cimport new_affinematrix3d
@@ -397,6 +397,16 @@ cdef class Quaternion:
         # normalise and rescale quaternion
         n = 1.0 / n
         return self.mul_scalar(n)
+
+    cpdef bint is_unit(self, double tolerance=1e-10):
+        """
+        Returns True if this is a unit quaternion (versor) to within specified tolerance.
+
+        :param float tolerance: the tested numerical tolerance by which the quaternion norm can differ by 1.0.
+        
+        
+        """
+        return fabs(1.0 - self.norm()) < tolerance
 
     cpdef Quaternion copy(self):
         """Returns a copy of this quaternion."""

--- a/raysect/core/math/quaternion.pyx
+++ b/raysect/core/math/quaternion.pyx
@@ -414,13 +414,13 @@ cdef class Quaternion:
                                   m20, m21, m22, 0,
                                   0, 0, 0, 1)
 
-    cpdef Quaternion rotation_to(self, Quaternion q):
+    cpdef Quaternion quaternion_to(self, Quaternion q):
         """
-        Calculates the rotation between quaternions.
+        Calculates the quaternion between quaternions.
 
-        This method calculates the rotation quaternion required to rotate this
-        quaternion onto the supplied quaternion. Both quaternions will be
-        normalised and a normalised quaternion will be returned.
+        This method calculates the quaternion required to map this quaternion
+        onto the supplied quaternion. Both quaternions will be normalised and
+        a normalised quaternion will be returned.
         
         .. code-block:: pycon
         
@@ -428,7 +428,7 @@ cdef class Quaternion:
           >>>
           >>> q1 = Quaternion.from_axis_angle(Vector3D(1,0,0), 10) 
           >>> q2 = Quaternion.from_axis_angle(Vector3D(1,0,0), 25)
-          >>> d = q1.rotate_to(q2)
+          >>> d = q1.quaternion_to(q2)
           >>> d
           Quaternion(0.13052619222005157, 0.0, 0.0, 0.9914448613738104)
           >>> d.angle

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -599,198 +599,198 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(answer.s, result.s, delta=1e-6,
                                msg="Extracting quaternion from AffineMatrix3D produced wrong result [S].")
 
-    def test_rotation_delta(self):
-        """Test the rotation_delta() function."""
-
-        # reference vectors
-        x = Vector3D(1, 0, 0)
-        y = Vector3D(0, 1, 0)
-        z = Vector3D(0, 0, 1)
-
-        # rotate around x 90 degrees every second
-        omega = Vector3D(90, 0, 0)
-
-        # x should be un-effected by the rotations at all times
-        # z should return to its starting position over 4 seconds
-
-        # testing 0.5 seconds
-        q = rotation_delta(omega, 0.5)
-        xr = q.transform_vector(x)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        # testing 1 seconds
-        q = rotation_delta(omega, 1)
-        xr = q.transform_vector(x)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        # testing 2 seconds
-        q = rotation_delta(omega, 2)
-        xr = q.transform_vector(x)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, -1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        # testing 2.5 seconds
-        q = rotation_delta(omega, 2.5)
-        xr = q.transform_vector(x)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        # testing 4 seconds
-        q = rotation_delta(omega, 4)
-        xr = q.transform_vector(x)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        omega = Vector3D(0, 90, 0)
-        q = rotation_delta(omega, 0.5)
-        xr = q.transform_vector(x)
-        yr = q.transform_vector(y)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        omega = Vector3D(0, 0, 90)
-        q = rotation_delta(omega, 0.5)
-        xr = q.transform_vector(x)
-        yr = q.transform_vector(y)
-        zr = q.transform_vector(z)
-        self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.y, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(xr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        omega = Vector3D(1/sqrt(2)*90, 0, 1/sqrt(2)*90)
-        q = rotation_delta(omega, 0.5)
-        yr = q.transform_vector(y)
-        self.assertAlmostEqual(yr.x, 0.5, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, -0.5, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        q = rotation_delta(omega, 1)
-        yr = q.transform_vector(y)
-        self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        q = rotation_delta(omega, 2)
-        yr = q.transform_vector(y)
-        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, -1, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        q = rotation_delta(omega, 3)
-        yr = q.transform_vector(y)
-        self.assertAlmostEqual(yr.x, -1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, 1/sqrt(2), delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-
-        q = rotation_delta(omega, 4)
-        yr = q.transform_vector(y)
-        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.y, 1.0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
-        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-                               msg="Calculating the rotation delta from an angular velocity failed.")
+    # def test_rotation_delta(self):
+    #     """Test the rotation_delta() function."""
+    #
+    #     # reference vectors
+    #     x = Vector3D(1, 0, 0)
+    #     y = Vector3D(0, 1, 0)
+    #     z = Vector3D(0, 0, 1)
+    #
+    #     # rotate around x 90 degrees every second
+    #     omega = Vector3D(90, 0, 0)
+    #
+    #     # x should be un-effected by the rotations at all times
+    #     # z should return to its starting position over 4 seconds
+    #
+    #     # testing 0.5 seconds
+    #     q = rotation_delta(omega, 0.5)
+    #     xr = q.transform_vector(x)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     # testing 1 seconds
+    #     q = rotation_delta(omega, 1)
+    #     xr = q.transform_vector(x)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     # testing 2 seconds
+    #     q = rotation_delta(omega, 2)
+    #     xr = q.transform_vector(x)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, -1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     # testing 2.5 seconds
+    #     q = rotation_delta(omega, 2.5)
+    #     xr = q.transform_vector(x)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     # testing 4 seconds
+    #     q = rotation_delta(omega, 4)
+    #     xr = q.transform_vector(x)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     omega = Vector3D(0, 90, 0)
+    #     q = rotation_delta(omega, 0.5)
+    #     xr = q.transform_vector(x)
+    #     yr = q.transform_vector(y)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     omega = Vector3D(0, 0, 90)
+    #     q = rotation_delta(omega, 0.5)
+    #     xr = q.transform_vector(x)
+    #     yr = q.transform_vector(y)
+    #     zr = q.transform_vector(z)
+    #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.y, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(xr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     omega = Vector3D(1/sqrt(2)*90, 0, 1/sqrt(2)*90)
+    #     q = rotation_delta(omega, 0.5)
+    #     yr = q.transform_vector(y)
+    #     self.assertAlmostEqual(yr.x, 0.5, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, -0.5, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     q = rotation_delta(omega, 1)
+    #     yr = q.transform_vector(y)
+    #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     q = rotation_delta(omega, 2)
+    #     yr = q.transform_vector(y)
+    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, -1, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     q = rotation_delta(omega, 3)
+    #     yr = q.transform_vector(y)
+    #     self.assertAlmostEqual(yr.x, -1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, 1/sqrt(2), delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #
+    #     q = rotation_delta(omega, 4)
+    #     yr = q.transform_vector(y)
+    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.y, 1.0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+    #                            msg="Calculating the rotation delta from an angular velocity failed.")
 
 
 if __name__ == "__main__":

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -32,7 +32,8 @@ Unit tests for the Quaternion object.
 """
 
 import unittest
-from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x
+from math import sqrt
+from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x, rotation_delta
 
 
 class TestQuaternion(unittest.TestCase):
@@ -574,6 +575,152 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(answer.s, result.s, delta=1e-6,
                                msg="Extracting quaternion from AffineMatrix3D produced wrong result [S].")
 
+    def test_rotation_delta(self):
+        """Test the rotation_delta() function."""
+
+        # reference vectors
+        x = Vector3D(1, 0, 0)
+        y = Vector3D(0, 1, 0)
+        z = Vector3D(0, 0, 1)
+
+        # rotate around x 90 degrees every second
+        omega = Vector3D(90, 0, 0)
+
+        # x should be un-effected by the rotations at all times
+        # z should return to its starting position over 4 seconds
+
+        # testing 0.5 seconds
+        q = rotation_delta(omega, 0.5)
+        xr = q.transform_vector(x)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        # testing 1 seconds
+        q = rotation_delta(omega, 1)
+        xr = q.transform_vector(x)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        # testing 2 seconds
+        q = rotation_delta(omega, 2)
+        xr = q.transform_vector(x)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, -1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        # testing 2.5 seconds
+        q = rotation_delta(omega, 2.5)
+        xr = q.transform_vector(x)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        # testing 4 seconds
+        q = rotation_delta(omega, 4)
+        xr = q.transform_vector(x)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, 1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        omega = Vector3D(0, 90, 0)
+        q = rotation_delta(omega, 0.5)
+        xr = q.transform_vector(x)
+        yr = q.transform_vector(y)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        omega = Vector3D(0, 0, 90)
+        q = rotation_delta(omega, 0.5)
+        xr = q.transform_vector(x)
+        yr = q.transform_vector(y)
+        zr = q.transform_vector(z)
+        self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.y, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(xr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(zr.z, 1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -722,5 +722,52 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(zr.z, 1, delta=1e-10,
                                msg="Calculating the rotation delta from an angular velocity failed.")
 
+        omega = Vector3D(1/sqrt(2)*90, 0, 1/sqrt(2)*90)
+        q = rotation_delta(omega, 0.5)
+        yr = q.transform_vector(y)
+        self.assertAlmostEqual(yr.x, 0.5, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, -0.5, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        q = rotation_delta(omega, 1)
+        yr = q.transform_vector(y)
+        self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        q = rotation_delta(omega, 2)
+        yr = q.transform_vector(y)
+        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, -1, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        q = rotation_delta(omega, 3)
+        yr = q.transform_vector(y)
+        self.assertAlmostEqual(yr.x, -1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, 1/sqrt(2), delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+        q = rotation_delta(omega, 4)
+        yr = q.transform_vector(y)
+        self.assertAlmostEqual(yr.x, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.y, 1.0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+        self.assertAlmostEqual(yr.z, 0, delta=1e-10,
+                               msg="Calculating the rotation delta from an angular velocity failed.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -314,6 +314,45 @@ class TestQuaternion(unittest.TestCase):
         self.assertEqual(r.z, 3.0, "Copy failed [Z].")
         self.assertEqual(r.s, 4.0, "Copy failed [S].")
 
+    def test_transform(self):
+        """Testing method transform()"""
+
+        q = Quaternion(0, 1, 0, 1).normalise()
+
+        v_result = q.transform(Vector3D(1, 1, 1))
+        self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+
+        v_result = q.transform(Vector3D(2, 3, 4))
+        self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.z, 2, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+
+        q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
+
+        v_result = q.transform(Vector3D(1, 1, 1))
+        self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+
+        v_result = q.transform(Vector3D(2, 3, 4))
+        self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(v_result.z, 0.9333333333333322, delta=1e-10,
+                               msg="Quaternion transform on a vector failed to produce the correct result.")
+
     def test_to_matrix(self):
         """Test AffineMatrix3D generation from a quaternion"""
 

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -429,12 +429,12 @@ class TestQuaternion(unittest.TestCase):
         self.assertEqual(r.z, 3.0, "Copy failed [Z].")
         self.assertEqual(r.s, 4.0, "Copy failed [S].")
 
-    def test_transform(self):
-        """Testing method transform()"""
+    def test_transform_vector(self):
+        """Testing method transform_vector()"""
 
         q = Quaternion(0, 1, 0, 1).normalise()
 
-        v_result = q.transform(Vector3D(1, 1, 1))
+        v_result = q.transform_vector(Vector3D(1, 1, 1))
         self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
         self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
@@ -442,7 +442,7 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
 
-        v_result = q.transform(Vector3D(2, 3, 4))
+        v_result = q.transform_vector(Vector3D(2, 3, 4))
         self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
         self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
@@ -452,7 +452,7 @@ class TestQuaternion(unittest.TestCase):
 
         q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
 
-        v_result = q.transform(Vector3D(1, 1, 1))
+        v_result = q.transform_vector(Vector3D(1, 1, 1))
         self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
         self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
@@ -460,7 +460,7 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
 
-        v_result = q.transform(Vector3D(2, 3, 4))
+        v_result = q.transform_vector(Vector3D(2, 3, 4))
         self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
                                msg="Quaternion transform on a vector failed to produce the correct result.")
         self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -33,7 +33,7 @@ Unit tests for the Quaternion object.
 
 import unittest
 from math import sqrt
-from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x, rotation_delta
+from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x, rotate_z, rotation_delta
 
 
 class TestQuaternion(unittest.TestCase):
@@ -275,13 +275,13 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(q_result.s, 0.5, delta=1e-10,
                                msg="Inverse of a quaternion failed to produce the correct result [S].")
 
-    def test_norm(self):
-        """Norm of a quaternion"""
+    def test_length(self):
+        """Length (norm) of a quaternion"""
 
         q = Quaternion(2, 3, 4, 1)
 
-        self.assertAlmostEqual(q.norm(), 5.477225575051661, delta=1e-10,
-                               msg="Norm of a quaternion failed to produce the correct result.")
+        self.assertAlmostEqual(q.length, 5.477225575051661, delta=1e-10,
+                               msg="Length of a quaternion failed to produce the correct result.")
 
     def test_normalise(self):
         """Normalising a quaternion"""
@@ -372,46 +372,46 @@ class TestQuaternion(unittest.TestCase):
                                msg="Decomposition of a quaternion into axis angle representation "
                                    "failed to produce the correct result.")
 
-    def test_euler_angle_decomposition(self):
-
-        q = Quaternion(0, 0, 0, 1)
-        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
-
-        self.assertAlmostEqual(yaw, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(pitch, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(roll, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-
-        q = Quaternion(1, 1, 1, 1)
-        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
-
-        self.assertAlmostEqual(yaw, 90, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(pitch, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(roll, 90, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-
-        q = Quaternion(2, 3, 4, 1)
-        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
-
-        self.assertAlmostEqual(yaw, 81.86989764584403, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(pitch, -19.471220634490695, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
-        self.assertAlmostEqual(roll, 135, delta=1e-10,
-                               msg="Decomposition of a quaternion into euler angle representation "
-                                   "failed to produce the correct result.")
+    # def test_euler_angle_decomposition(self):
+    #
+    #     q = Quaternion(0, 0, 0, 1)
+    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #
+    #     self.assertAlmostEqual(yaw, 0, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(roll, 0, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #
+    #     q = Quaternion(1, 1, 1, 1)
+    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #
+    #     self.assertAlmostEqual(yaw, 90, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(roll, 90, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #
+    #     q = Quaternion(2, 3, 4, 1)
+    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #
+    #     self.assertAlmostEqual(yaw, 81.86989764584403, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(pitch, -19.471220634490695, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
+    #     self.assertAlmostEqual(roll, 135, delta=1e-10,
+    #                            msg="Decomposition of a quaternion into euler angle representation "
+    #                                "failed to produce the correct result.")
 
     def test_copy(self):
         """Testing method copy()"""
@@ -430,44 +430,68 @@ class TestQuaternion(unittest.TestCase):
         self.assertEqual(r.z, 3.0, "Copy failed [Z].")
         self.assertEqual(r.s, 4.0, "Copy failed [S].")
 
-    def test_transform_vector(self):
-        """Testing method transform_vector()"""
+    def test_transform(self):
 
-        q = Quaternion(0, 1, 0, 1).normalise()
+        # transform between space 1 and space 2
+        m = rotate_z(47)
 
-        v_result = q.transform_vector(Vector3D(1, 1, 1))
-        self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        # define in coordinate space 1
+        v1 = Vector3D(1, 0.3, -0.2)
+        q1 = Quaternion.from_axis_angle(Vector3D(0.1, -0.7, 0.2), 57)
 
-        v_result = q.transform_vector(Vector3D(2, 3, 4))
-        self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.z, 2, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        # transform to coordinate space 2
+        v2 = v1.transform(m)
+        q2 = q1.transform(m)
 
-        q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
+        # use quaternion to rotate vector in each space
+        r1 = v1.transform(q1.to_matrix())
+        r2 = v2.transform(q2.to_matrix())
 
-        v_result = q.transform_vector(Vector3D(1, 1, 1))
-        self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        # convert result in space 2 to space 1 for comparison
+        r2_1 = r2.transform(m.inverse())
 
-        v_result = q.transform_vector(Vector3D(2, 3, 4))
-        self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
-        self.assertAlmostEqual(v_result.z, 0.9333333333333322, delta=1e-10,
-                               msg="Quaternion transform on a vector failed to produce the correct result.")
+        self.assertAlmostEqual(r1.x, r2_1.x, delta=1e-10, msg='Transform failed [X]')
+        self.assertAlmostEqual(r1.y, r2_1.y, delta=1e-10, msg='Transform failed [Y]')
+        self.assertAlmostEqual(r1.z, r2_1.z, delta=1e-10, msg='Transform failed [Z]')
+
+    # def test_transform_vector(self):
+    #     """Testing method transform_vector()"""
+    #
+    #     q = Quaternion(0, 1, 0, 1).normalise()
+    #
+    #     v_result = q.transform_vector(Vector3D(1, 1, 1))
+    #     self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #
+    #     v_result = q.transform_vector(Vector3D(2, 3, 4))
+    #     self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.z, 2, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #
+    #     q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
+    #
+    #     v_result = q.transform_vector(Vector3D(1, 1, 1))
+    #     self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #
+    #     v_result = q.transform_vector(Vector3D(2, 3, 4))
+    #     self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #     self.assertAlmostEqual(v_result.z, 0.9333333333333322, delta=1e-10,
+    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
 
     def test_to_matrix(self):
         """Test AffineMatrix3D generation from a quaternion"""

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -371,6 +371,47 @@ class TestQuaternion(unittest.TestCase):
                                msg="Decomposition of a quaternion into axis angle representation "
                                    "failed to produce the correct result.")
 
+    def test_euler_angle_decomposition(self):
+
+        q = Quaternion(0, 0, 0, 1)
+        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+
+        self.assertAlmostEqual(yaw, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(pitch, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(roll, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+
+        q = Quaternion(1, 1, 1, 1)
+        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+
+        self.assertAlmostEqual(yaw, 90, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(pitch, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(roll, 90, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+
+        q = Quaternion(2, 3, 4, 1)
+        yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+
+        self.assertAlmostEqual(yaw, 81.86989764584403, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(pitch, -19.471220634490695, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(roll, 135, delta=1e-10,
+                               msg="Decomposition of a quaternion into euler angle representation "
+                                   "failed to produce the correct result.")
+
     def test_copy(self):
         """Testing method copy()"""
 

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -318,6 +318,59 @@ class TestQuaternion(unittest.TestCase):
         self.assertFalse(Quaternion(-0.777777, 3.1214352, -0.9483527, 3.1415).is_unit(),
                          "Quaternion is_unit() test failed to produce the correct result.")
 
+    def test_axis_angle_decomposition(self):
+
+        q = Quaternion(1, 1, 1, 1)
+        axis = q.axis
+        angle = q.angle
+
+        self.assertAlmostEqual(axis.x, 0.5773502691896258, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.y, 0.5773502691896258, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.z, 0.5773502691896258, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(angle, 120, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+
+        q = Quaternion(2, 3, 4, 1)
+        axis = q.axis
+        angle = q.angle
+
+        self.assertAlmostEqual(axis.x, 0.3713906763541038, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.y, 0.5570860145311557, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.z, 0.7427813527082076, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(angle, 158.96053021868278, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+
+        q = Quaternion(0, 0, 0, 1)
+        axis = q.axis
+        angle = q.angle
+
+        self.assertAlmostEqual(axis.x, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.y, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(axis.z, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+        self.assertAlmostEqual(angle, 0, delta=1e-10,
+                               msg="Decomposition of a quaternion into axis angle representation "
+                                   "failed to produce the correct result.")
+
     def test_copy(self):
         """Testing method copy()"""
 

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -297,6 +297,27 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(q_result.s, 0.18257418583505536, delta=1e-10,
                                msg="Norm of a quaternion failed to produce the correct result.")
 
+    def test_is_unit(self):
+        """Testing method is_unit()"""
+
+        self.assertTrue(Quaternion(1, 0, 0, 0).is_unit(),
+                        "Quaternion is_unit() test failed to produce the correct result.")
+
+        self.assertTrue(Quaternion(0, 1, 0, 0).is_unit(),
+                        "Quaternion is_unit() test failed to produce the correct result.")
+
+        self.assertTrue(Quaternion(0, 0, 1, 0).is_unit(),
+                        "Quaternion is_unit() test failed to produce the correct result.")
+
+        self.assertTrue(Quaternion(0, 0, 0, 1).is_unit(),
+                        "Quaternion is_unit() test failed to produce the correct result.")
+
+        self.assertFalse(Quaternion(1, 2, 3, 4).is_unit(),
+                         "Quaternion is_unit() test failed to produce the correct result.")
+
+        self.assertFalse(Quaternion(-0.777777, 3.1214352, -0.9483527, 3.1415).is_unit(),
+                         "Quaternion is_unit() test failed to produce the correct result.")
+
     def test_copy(self):
         """Testing method copy()"""
 

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -15,7 +15,7 @@
 #        contributors may be used to endorse or promote products derived from
 #        this software without specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -33,7 +33,7 @@ Unit tests for the Quaternion object.
 
 import unittest
 from math import sqrt
-from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x, rotate_z, rotation_delta
+from raysect.core.math import Quaternion, AffineMatrix3D, Vector3D, rotate_x, rotate_z
 
 
 class TestQuaternion(unittest.TestCase):
@@ -42,25 +42,25 @@ class TestQuaternion(unittest.TestCase):
         """Default initialisation, identity quaternion."""
 
         q = Quaternion()
-        self.assertEqual(q.x, 0.0, "Default initialisation is not (<0,0,0>,1) [X].")
-        self.assertEqual(q.y, 0.0, "Default initialisation is not (<0,0,0>,1) [Y].")
-        self.assertEqual(q.z, 0.0, "Default initialisation is not (<0,0,0>,1) [Z].")
-        self.assertEqual(q.s, 1.0, "Default initialisation is not (<0,0,0>,1) [S].")
+        self.assertEqual(q.x, 0.0, 'Default initialisation is not (<0,0,0>,1) [X].')
+        self.assertEqual(q.y, 0.0, 'Default initialisation is not (<0,0,0>,1) [Y].')
+        self.assertEqual(q.z, 0.0, 'Default initialisation is not (<0,0,0>,1) [Z].')
+        self.assertEqual(q.s, 1.0, 'Default initialisation is not (<0,0,0>,1) [S].')
 
     def test_initialise_indexable(self):
         """Initialisation with an indexable object."""
 
         q = Quaternion(1.0, 2.0, 3.0, 4.0)
-        self.assertEqual(q.x, 1.0, "Initialisation with indexable failed [X].")
-        self.assertEqual(q.y, 2.0, "Initialisation with indexable failed [Y].")
-        self.assertEqual(q.z, 3.0, "Initialisation with indexable failed [Z].")
-        self.assertEqual(q.s, 4.0, "Initialisation with indexable failed [S].")
+        self.assertEqual(q.x, 1.0, 'Initialisation with indexable failed [X].')
+        self.assertEqual(q.y, 2.0, 'Initialisation with indexable failed [Y].')
+        self.assertEqual(q.z, 3.0, 'Initialisation with indexable failed [Z].')
+        self.assertEqual(q.s, 4.0, 'Initialisation with indexable failed [S].')
 
     def test_initialise_invalid(self):
         """Initialisation with invalid types should raise a TypeError."""
 
-        with self.assertRaises(TypeError, msg="Initialised with a string."):
-            Quaternion("spoon")
+        with self.assertRaises(TypeError, msg='Initialised with a string.'):
+            Quaternion('spoon')
 
     def test_x(self):
         """Get/set x co-ordinate."""
@@ -68,11 +68,11 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(2.5, 6.7, -4.6, 1.0)
 
         # get x attribute
-        self.assertEqual(q.x, 2.5, "Getting x attribute failed.")
+        self.assertEqual(q.x, 2.5, 'Getting x attribute failed.')
 
         # set x attribute
         q.x = 10.0
-        self.assertEqual(q.x, 10.0, "Setting x attribute failed.")
+        self.assertEqual(q.x, 10.0, 'Setting x attribute failed.')
 
     def test_y(self):
         """Get/set y co-ordinate."""
@@ -80,11 +80,11 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(2.5, 6.7, -4.6, 1.0)
 
         # get y attribute
-        self.assertEqual(q.y, 6.7, "Getting y attribute failed.")
+        self.assertEqual(q.y, 6.7, 'Getting y attribute failed.')
 
         # set y attribute
         q.y = -7.1
-        self.assertEqual(q.y, -7.1, "Setting y attribute failed.")
+        self.assertEqual(q.y, -7.1, 'Setting y attribute failed.')
 
     def test_z(self):
         """Get/set z co-ordinate."""
@@ -92,11 +92,11 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(2.5, 6.7, -4.6, 1.0)
 
         # get z attribute
-        self.assertEqual(q.z, -4.6, "Getting z attribute failed.")
+        self.assertEqual(q.z, -4.6, 'Getting z attribute failed.')
 
         # set z attribute
         q.z = 157.3
-        self.assertEqual(q.z, 157.3, "Setting z attribute failed.")
+        self.assertEqual(q.z, 157.3, 'Setting z attribute failed.')
 
     def test_s(self):
         """Get/set s co-ordinate."""
@@ -104,11 +104,11 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(2.5, 6.7, -4.6, 1.0)
 
         # get x attribute
-        self.assertEqual(q.s, 1.0, "Getting s attribute failed.")
+        self.assertEqual(q.s, 1.0, 'Getting s attribute failed.')
 
         # set x attribute
         q.s = 10.0
-        self.assertEqual(q.s, 10.0, "Setting s attribute failed.")
+        self.assertEqual(q.s, 10.0, 'Setting s attribute failed.')
 
     def test_indexing(self):
         """Getting/setting components by indexing."""
@@ -121,56 +121,56 @@ class TestQuaternion(unittest.TestCase):
         q[3] = 1.5
 
         # check getting/setting via valid indexes
-        self.assertEqual(q[0], 2.0, "Indexing failed [X].")
-        self.assertEqual(q[1], 7.0, "Indexing failed [Y].")
-        self.assertEqual(q[2], 10.0, "Indexing failed [Z].")
-        self.assertEqual(q[3], 1.5, "Indexing failed [S].")
+        self.assertEqual(q[0], 2.0, 'Indexing failed [X].')
+        self.assertEqual(q[1], 7.0, 'Indexing failed [Y].')
+        self.assertEqual(q[2], 10.0, 'Indexing failed [Z].')
+        self.assertEqual(q[3], 1.5, 'Indexing failed [S].')
 
         # check invalid indexes
-        with self.assertRaises(IndexError, msg="Invalid positive index did not raise IndexError."):
+        with self.assertRaises(IndexError, msg='Invalid positive index did not raise IndexError.'):
             r = q[4]
 
-        with self.assertRaises(IndexError, msg="Invalid negative index did not raise IndexError."):
+        with self.assertRaises(IndexError, msg='Invalid negative index did not raise IndexError.'):
             r = q[-1]
 
     def test_equal(self):
         """Equality operator."""
 
         self.assertTrue(Quaternion(1, 2, 3, 4) == Quaternion(1, 2, 3, 4),
-                        "Equality operator returned false for equal quaternions.")
+                        'Equality operator returned false for equal quaternions.')
         self.assertFalse(Quaternion(5, 2, 3, 4) == Quaternion(1, 2, 3, 4),
-                         "Equality operator returned true for quaternions with non-equal x components.")
+                         'Equality operator returned true for quaternions with non-equal x components.')
         self.assertFalse(Quaternion(1, 5, 3, 4) == Quaternion(1, 2, 3, 4),
-                         "Equality operator returned true for quaternions with non-equal y components.")
+                         'Equality operator returned true for quaternions with non-equal y components.')
         self.assertFalse(Quaternion(1, 2, 5, 4) == Quaternion(1, 2, 3, 4),
-                         "Equality operator returned true for quaternions with non-equal z components.")
+                         'Equality operator returned true for quaternions with non-equal z components.')
         self.assertFalse(Quaternion(1, 2, 3, 5) == Quaternion(1, 2, 3, 4),
-                         "Equality operator returned true for quaternions with non-equal s components.")
+                         'Equality operator returned true for quaternions with non-equal s components.')
 
     def test_not_equal(self):
         """Inequality operator."""
 
         self.assertFalse(Quaternion(1, 2, 3, 4) != Quaternion(1, 2, 3, 4),
-                         "Inequality operator returned true for equal quaternions.")
+                         'Inequality operator returned true for equal quaternions.')
         self.assertTrue(Quaternion(5, 1, 3, 4) != Quaternion(1, 2, 3, 4),
-                        "Inequality operator returned false for quaternions with non-equal x components.")
+                        'Inequality operator returned false for quaternions with non-equal x components.')
         self.assertTrue(Quaternion(1, 5, 3, 4) != Quaternion(1, 2, 3, 4),
-                        "Inequality operator returned false for quaternions with non-equal y components.")
+                        'Inequality operator returned false for quaternions with non-equal y components.')
         self.assertTrue(Quaternion(1, 2, 5, 4) != Quaternion(1, 2, 3, 4),
-                        "Inequality operator returned false for quaternions with non-equal z components.")
+                        'Inequality operator returned false for quaternions with non-equal z components.')
         self.assertTrue(Quaternion(1, 2, 3, 5) != Quaternion(1, 2, 3, 4),
-                        "Inequality operator returned false for quaternions with non-equal s components.")
+                        'Inequality operator returned false for quaternions with non-equal s components.')
 
     def test_iter(self):
         """Obtain values by iteration."""
 
         q = Quaternion(2.5, 6.7, -4.6, 1.0)
         l = list(q)
-        self.assertEqual(len(l), 4, "Iteration failed to return the correct number of items.")
-        self.assertEqual(l[0], 2.5, "Iteration failed [X].")
-        self.assertEqual(l[1], 6.7, "Iteration failed [Y].")
-        self.assertEqual(l[2], -4.6, "Iteration failed [Z].")
-        self.assertEqual(l[3], 1.0, "Iteration failed [S].")
+        self.assertEqual(len(l), 4, 'Iteration failed to return the correct number of items.')
+        self.assertEqual(l[0], 2.5, 'Iteration failed [X].')
+        self.assertEqual(l[1], 6.7, 'Iteration failed [Y].')
+        self.assertEqual(l[2], -4.6, 'Iteration failed [Z].')
+        self.assertEqual(l[3], 1.0, 'Iteration failed [S].')
 
     def test_add(self):
         """Addition operator."""
@@ -181,10 +181,10 @@ class TestQuaternion(unittest.TestCase):
         q_theory = Quaternion(4, 0, 14, 1)
         q_result = q1 + q2
 
-        self.assertEqual(q_result.x, q_theory.x, "Addition of two quaternions failed [X].")
-        self.assertEqual(q_result.y, q_theory.y, "Addition of two quaternions failed [Y].")
-        self.assertEqual(q_result.z, q_theory.z, "Addition of two quaternions failed [Z].")
-        self.assertEqual(q_result.s, q_theory.s, "Addition of two quaternions failed [S].")
+        self.assertEqual(q_result.x, q_theory.x, 'Addition of two quaternions failed [X].')
+        self.assertEqual(q_result.y, q_theory.y, 'Addition of two quaternions failed [Y].')
+        self.assertEqual(q_result.z, q_theory.z, 'Addition of two quaternions failed [Z].')
+        self.assertEqual(q_result.s, q_theory.s, 'Addition of two quaternions failed [S].')
 
     def test_subtract(self):
         """Subtraction operator."""
@@ -196,10 +196,10 @@ class TestQuaternion(unittest.TestCase):
         q_theory = Quaternion(0, 6, -6, 1)
         q_result = q1 - q2
 
-        self.assertEqual(q_result.x, q_theory.x, "Subtraction of two quaternions failed [X].")
-        self.assertEqual(q_result.y, q_theory.y, "Subtraction of two quaternions failed [Y].")
-        self.assertEqual(q_result.z, q_theory.z, "Subtraction of two quaternions failed [Z].")
-        self.assertEqual(q_result.s, q_theory.s, "Subtraction of two quaternions failed [S].")
+        self.assertEqual(q_result.x, q_theory.x, 'Subtraction of two quaternions failed [X].')
+        self.assertEqual(q_result.y, q_theory.y, 'Subtraction of two quaternions failed [Y].')
+        self.assertEqual(q_result.z, q_theory.z, 'Subtraction of two quaternions failed [Z].')
+        self.assertEqual(q_result.s, q_theory.s, 'Subtraction of two quaternions failed [S].')
 
     def test_negation(self):
         """Negation operation"""
@@ -207,7 +207,7 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(1, 2, 3, 4)
         q_result = Quaternion(-1, -2, -3, -4)
 
-        self.assertTrue(-q == q_result, "Negation of a quaternion failed to produce the correct result.")
+        self.assertTrue(-q == q_result, 'Negation of a quaternion failed to produce the correct result.')
 
     def test_multiplication(self):
         """Multiplication operation"""
@@ -217,12 +217,12 @@ class TestQuaternion(unittest.TestCase):
 
         q_result = Quaternion(0, 3, 0, 3)
         self.assertTrue(q1 * 3 == q_result,
-                        "Multiplication of a quaternion and a scalar failed to produce the correct result.")
+                        'Multiplication of a quaternion and a scalar failed to produce the correct result.')
         self.assertTrue(3 * q1 == q_result,
-                        "Multiplication of a quaternion and a scalar failed to produce the correct result.")
+                        'Multiplication of a quaternion and a scalar failed to produce the correct result.')
 
         q_result = Quaternion(1.25, 1.5, 0.25, 0.5)
-        self.assertTrue(q1 * q2 == q_result, "Multiplication of two quaternions failed to produce the correct result.")
+        self.assertTrue(q1 * q2 == q_result, 'Multiplication of two quaternions failed to produce the correct result.')
 
     def test_division(self):
         """Division operation"""
@@ -234,17 +234,17 @@ class TestQuaternion(unittest.TestCase):
         q_result = q1 / q2
 
         self.assertAlmostEqual(q_result.x, q_theory.x, delta=1e-10,
-                               msg="Division of two quaternions failed to produce the correct result [X].")
+                               msg='Division of two quaternions failed to produce the correct result [X].')
         self.assertAlmostEqual(q_result.y, q_theory.y, delta=1e-10,
-                               msg="Division of two quaternions failed to produce the correct result [Y].")
+                               msg='Division of two quaternions failed to produce the correct result [Y].')
         self.assertAlmostEqual(q_result.z, q_theory.z, delta=1e-10,
-                               msg="Division of two quaternions failed to produce the correct result [Z].")
+                               msg='Division of two quaternions failed to produce the correct result [Z].')
         self.assertAlmostEqual(q_result.s, q_theory.s, delta=1e-10,
-                               msg="Division of two quaternions failed to produce the correct result [S].")
+                               msg='Division of two quaternions failed to produce the correct result [S].')
 
         q_result = Quaternion(0.25, 0.25, 0.375, 0.5)
         self.assertTrue(q2 / 2 == q_result,
-                        "Division of a quaternion and a scalar failed to produce the correct result.")
+                        'Division of a quaternion and a scalar failed to produce the correct result.')
 
     def test_conjugate(self):
         """Test conjugation operation"""
@@ -254,11 +254,11 @@ class TestQuaternion(unittest.TestCase):
         answer = Quaternion(-2, 3, 0, 1)
 
         self.assertEqual(result.x, answer.x,
-                         msg="Conjugation of a Quaternion failed to produce the correct result [X].")
+                         msg='Conjugation of a Quaternion failed to produce the correct result [X].')
         self.assertEqual(result.y, answer.y,
-                         msg="Conjugation of a Quaternion failed to produce the correct result [Y].")
+                         msg='Conjugation of a Quaternion failed to produce the correct result [Y].')
         self.assertEqual(result.z, answer.z,
-                         msg="Conjugation of a Quaternion failed to produce the correct result [Z].")
+                         msg='Conjugation of a Quaternion failed to produce the correct result [Z].')
 
     def test_inverse(self):
         """Inverse operation"""
@@ -267,13 +267,13 @@ class TestQuaternion(unittest.TestCase):
         q_result = q.inverse()
 
         self.assertAlmostEqual(q_result.x, 0, delta=1e-10,
-                               msg="Inverse of a quaternion failed to produce the correct result [X].")
+                               msg='Inverse of a quaternion failed to produce the correct result [X].')
         self.assertAlmostEqual(q_result.y, -0.5, delta=1e-10,
-                               msg="Inverse of a quaternion failed to produce the correct result [Y].")
+                               msg='Inverse of a quaternion failed to produce the correct result [Y].')
         self.assertAlmostEqual(q_result.z, 0, delta=1e-10,
-                               msg="Inverse of a quaternion failed to produce the correct result [Z].")
+                               msg='Inverse of a quaternion failed to produce the correct result [Z].')
         self.assertAlmostEqual(q_result.s, 0.5, delta=1e-10,
-                               msg="Inverse of a quaternion failed to produce the correct result [S].")
+                               msg='Inverse of a quaternion failed to produce the correct result [S].')
 
     def test_length(self):
         """Length (norm) of a quaternion"""
@@ -281,7 +281,7 @@ class TestQuaternion(unittest.TestCase):
         q = Quaternion(2, 3, 4, 1)
 
         self.assertAlmostEqual(q.length, 5.477225575051661, delta=1e-10,
-                               msg="Length of a quaternion failed to produce the correct result.")
+                               msg='Length of a quaternion failed to produce the correct result.')
 
     def test_normalise(self):
         """Normalising a quaternion"""
@@ -290,34 +290,34 @@ class TestQuaternion(unittest.TestCase):
         q_result = q.normalise()
 
         self.assertAlmostEqual(q_result.x, 0.3651483716701107, delta=1e-10,
-                               msg="Norm of a quaternion failed to produce the correct result.")
+                               msg='Norm of a quaternion failed to produce the correct result.')
         self.assertAlmostEqual(q_result.y, 0.5477225575051661, delta=1e-10,
-                               msg="Norm of a quaternion failed to produce the correct result.")
+                               msg='Norm of a quaternion failed to produce the correct result.')
         self.assertAlmostEqual(q_result.z, 0.7302967433402214, delta=1e-10,
-                               msg="Norm of a quaternion failed to produce the correct result.")
+                               msg='Norm of a quaternion failed to produce the correct result.')
         self.assertAlmostEqual(q_result.s, 0.18257418583505536, delta=1e-10,
-                               msg="Norm of a quaternion failed to produce the correct result.")
+                               msg='Norm of a quaternion failed to produce the correct result.')
 
     def test_is_unit(self):
         """Testing method is_unit()"""
 
         self.assertTrue(Quaternion(1, 0, 0, 0).is_unit(),
-                        "Quaternion is_unit() test failed to produce the correct result.")
+                        'Quaternion is_unit() test failed to produce the correct result.')
 
         self.assertTrue(Quaternion(0, 1, 0, 0).is_unit(),
-                        "Quaternion is_unit() test failed to produce the correct result.")
+                        'Quaternion is_unit() test failed to produce the correct result.')
 
         self.assertTrue(Quaternion(0, 0, 1, 0).is_unit(),
-                        "Quaternion is_unit() test failed to produce the correct result.")
+                        'Quaternion is_unit() test failed to produce the correct result.')
 
         self.assertTrue(Quaternion(0, 0, 0, 1).is_unit(),
-                        "Quaternion is_unit() test failed to produce the correct result.")
+                        'Quaternion is_unit() test failed to produce the correct result.')
 
         self.assertFalse(Quaternion(1, 2, 3, 4).is_unit(),
-                         "Quaternion is_unit() test failed to produce the correct result.")
+                         'Quaternion is_unit() test failed to produce the correct result.')
 
         self.assertFalse(Quaternion(-0.777777, 3.1214352, -0.9483527, 3.1415).is_unit(),
-                         "Quaternion is_unit() test failed to produce the correct result.")
+                         'Quaternion is_unit() test failed to produce the correct result.')
 
     def test_axis_angle_decomposition(self):
 
@@ -326,92 +326,92 @@ class TestQuaternion(unittest.TestCase):
         angle = q.angle
 
         self.assertAlmostEqual(axis.x, 0.5773502691896258, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.y, 0.5773502691896258, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.z, 0.5773502691896258, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(angle, 120, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
 
         q = Quaternion(2, 3, 4, 1)
         axis = q.axis
         angle = q.angle
 
         self.assertAlmostEqual(axis.x, 0.3713906763541038, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.y, 0.5570860145311557, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.z, 0.7427813527082076, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(angle, 158.96053021868278, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
 
         q = Quaternion(0, 0, 0, 1)
         axis = q.axis
         angle = q.angle
 
         self.assertAlmostEqual(axis.x, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.y, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(axis.z, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
         self.assertAlmostEqual(angle, 0, delta=1e-10,
-                               msg="Decomposition of a quaternion into axis angle representation "
-                                   "failed to produce the correct result.")
+                               msg='Decomposition of a quaternion into axis angle representation '
+                                   'failed to produce the correct result.')
 
     # def test_euler_angle_decomposition(self):
     #
     #     q = Quaternion(0, 0, 0, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
     #
     #     self.assertAlmostEqual(yaw, 0, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(roll, 0, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #
     #     q = Quaternion(1, 1, 1, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
     #
     #     self.assertAlmostEqual(yaw, 90, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(roll, 90, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #
     #     q = Quaternion(2, 3, 4, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering="ZYX")
+    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
     #
     #     self.assertAlmostEqual(yaw, 81.86989764584403, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(pitch, -19.471220634490695, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
     #     self.assertAlmostEqual(roll, 135, delta=1e-10,
-    #                            msg="Decomposition of a quaternion into euler angle representation "
-    #                                "failed to produce the correct result.")
+    #                            msg='Decomposition of a quaternion into euler angle representation '
+    #                                'failed to produce the correct result.')
 
     def test_copy(self):
         """Testing method copy()"""
@@ -425,10 +425,10 @@ class TestQuaternion(unittest.TestCase):
         q.z = 7.0
         q.s = 8.0
 
-        self.assertEqual(r.x, 1.0, "Copy failed [X].")
-        self.assertEqual(r.y, 2.0, "Copy failed [Y].")
-        self.assertEqual(r.z, 3.0, "Copy failed [Z].")
-        self.assertEqual(r.s, 4.0, "Copy failed [S].")
+        self.assertEqual(r.x, 1.0, 'Copy failed [X].')
+        self.assertEqual(r.y, 2.0, 'Copy failed [Y].')
+        self.assertEqual(r.z, 3.0, 'Copy failed [Z].')
+        self.assertEqual(r.s, 4.0, 'Copy failed [S].')
 
     def test_transform(self):
 
@@ -461,42 +461,42 @@ class TestQuaternion(unittest.TestCase):
     #
     #     v_result = q.transform_vector(Vector3D(1, 1, 1))
     #     self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #
     #     v_result = q.transform_vector(Vector3D(2, 3, 4))
     #     self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.z, 2, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #
     #     q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
     #
     #     v_result = q.transform_vector(Vector3D(1, 1, 1))
     #     self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #
     #     v_result = q.transform_vector(Vector3D(2, 3, 4))
     #     self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
     #     self.assertAlmostEqual(v_result.z, 0.9333333333333322, delta=1e-10,
-    #                            msg="Quaternion transform on a vector failed to produce the correct result.")
+    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
 
     def test_to_matrix(self):
         """Test AffineMatrix3D generation from a quaternion"""
 
-        message = "Conversion of a Quaternion to AffineMatrix3D failed to produce the correct result."
+        message = 'Conversion of a Quaternion to AffineMatrix3D failed to produce the correct result.'
 
         matrix = Quaternion(0.5, 0, 0, 0.5).to_matrix()
         answer = rotate_x(90)
@@ -547,25 +547,25 @@ class TestQuaternion(unittest.TestCase):
         answer = Quaternion(0.3826834323650898, 0.0, 0.0, 0.9238795325112867)
 
         self.assertAlmostEqual(answer.x, result.x, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [X].")
+                               msg='Converting axis angle to quaternion produced wrong result [X].')
         self.assertAlmostEqual(answer.y, result.y, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [Y].")
+                               msg='Converting axis angle to quaternion produced wrong result [Y].')
         self.assertAlmostEqual(answer.z, result.z, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [Z].")
+                               msg='Converting axis angle to quaternion produced wrong result [Z].')
         self.assertAlmostEqual(answer.s, result.s, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [S].")
+                               msg='Converting axis angle to quaternion produced wrong result [S].')
 
         result = Quaternion.from_axis_angle(Vector3D(0.5, 0.5, 0), -30)
         answer = Quaternion(-0.1830127018922193, -0.1830127018922193, -0.0, 0.9659258262890683)
 
         self.assertAlmostEqual(answer.y, result.y, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [Y].")
+                               msg='Converting axis angle to quaternion produced wrong result [Y].')
         self.assertAlmostEqual(answer.z, result.z, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [Z].")
+                               msg='Converting axis angle to quaternion produced wrong result [Z].')
         self.assertAlmostEqual(answer.x, result.x, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [X].")
+                               msg='Converting axis angle to quaternion produced wrong result [X].')
         self.assertAlmostEqual(answer.s, result.s, delta=1e-10,
-                               msg="Converting axis angle to quaternion produced wrong result [S].")
+                               msg='Converting axis angle to quaternion produced wrong result [S].')
 
     def test_from_matrix(self):
         """Tests the extraction of a rotation quaternion from an AffineMatrix3D"""
@@ -574,13 +574,13 @@ class TestQuaternion(unittest.TestCase):
         answer = Quaternion(0.7071067811865475, 0.0, 0.0, 0.7071067811865476)
 
         self.assertAlmostEqual(answer.x, result.x, delta=1e-10,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [X].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [X].')
         self.assertAlmostEqual(answer.y, result.y, delta=1e-10,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [Y].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [Y].')
         self.assertAlmostEqual(answer.z, result.z, delta=1e-10,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [Z].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [Z].')
         self.assertAlmostEqual(answer.s, result.s, delta=1e-10,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [S].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [S].')
 
         matrix = AffineMatrix3D(((0.9330127, 0.0669873, -0.3535534, 0.0),
                                  (0.0669873, 0.9330127, 0.3535534, 0.0),
@@ -591,13 +591,13 @@ class TestQuaternion(unittest.TestCase):
         answer = Quaternion(-0.1830127018922193, -0.1830127018922193, -0.0, 0.9659258262890683)
 
         self.assertAlmostEqual(answer.x, result.x, delta=1e-6,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [X].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [X].')
         self.assertAlmostEqual(answer.y, result.y, delta=1e-6,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [Y].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [Y].')
         self.assertAlmostEqual(answer.z, result.z, delta=1e-6,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [Z].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [Z].')
         self.assertAlmostEqual(answer.s, result.s, delta=1e-6,
-                               msg="Extracting quaternion from AffineMatrix3D produced wrong result [S].")
+                               msg='Extracting quaternion from AffineMatrix3D produced wrong result [S].')
 
     # def test_rotation_delta(self):
     #     """Test the rotation_delta() function."""
@@ -618,85 +618,85 @@ class TestQuaternion(unittest.TestCase):
     #     xr = q.transform_vector(x)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     # testing 1 seconds
     #     q = rotation_delta(omega, 1)
     #     xr = q.transform_vector(x)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     # testing 2 seconds
     #     q = rotation_delta(omega, 2)
     #     xr = q.transform_vector(x)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, -1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     # testing 2.5 seconds
     #     q = rotation_delta(omega, 2.5)
     #     xr = q.transform_vector(x)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     # testing 4 seconds
     #     q = rotation_delta(omega, 4)
     #     xr = q.transform_vector(x)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     omega = Vector3D(0, 90, 0)
     #     q = rotation_delta(omega, 0.5)
@@ -704,23 +704,23 @@ class TestQuaternion(unittest.TestCase):
     #     yr = q.transform_vector(y)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     omega = Vector3D(0, 0, 90)
     #     q = rotation_delta(omega, 0.5)
@@ -728,70 +728,70 @@ class TestQuaternion(unittest.TestCase):
     #     yr = q.transform_vector(y)
     #     zr = q.transform_vector(z)
     #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.y, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(xr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     omega = Vector3D(1/sqrt(2)*90, 0, 1/sqrt(2)*90)
     #     q = rotation_delta(omega, 0.5)
     #     yr = q.transform_vector(y)
     #     self.assertAlmostEqual(yr.x, 0.5, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, -0.5, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     q = rotation_delta(omega, 1)
     #     yr = q.transform_vector(y)
     #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     q = rotation_delta(omega, 2)
     #     yr = q.transform_vector(y)
     #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, -1, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     q = rotation_delta(omega, 3)
     #     yr = q.transform_vector(y)
     #     self.assertAlmostEqual(yr.x, -1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #
     #     q = rotation_delta(omega, 4)
     #     yr = q.transform_vector(y)
     #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.y, 1.0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
     #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg="Calculating the rotation delta from an angular velocity failed.")
+    #                            msg='Calculating the rotation delta from an angular velocity failed.')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/raysect/core/math/tests/test_quaternion.py
+++ b/raysect/core/math/tests/test_quaternion.py
@@ -372,47 +372,6 @@ class TestQuaternion(unittest.TestCase):
                                msg='Decomposition of a quaternion into axis angle representation '
                                    'failed to produce the correct result.')
 
-    # def test_euler_angle_decomposition(self):
-    #
-    #     q = Quaternion(0, 0, 0, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
-    #
-    #     self.assertAlmostEqual(yaw, 0, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(roll, 0, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #
-    #     q = Quaternion(1, 1, 1, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
-    #
-    #     self.assertAlmostEqual(yaw, 90, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(pitch, 0, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(roll, 90, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #
-    #     q = Quaternion(2, 3, 4, 1)
-    #     yaw, pitch, roll = q.to_euler_angles(ordering='ZYX')
-    #
-    #     self.assertAlmostEqual(yaw, 81.86989764584403, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(pitch, -19.471220634490695, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-    #     self.assertAlmostEqual(roll, 135, delta=1e-10,
-    #                            msg='Decomposition of a quaternion into euler angle representation '
-    #                                'failed to produce the correct result.')
-
     def test_copy(self):
         """Testing method copy()"""
 
@@ -444,8 +403,8 @@ class TestQuaternion(unittest.TestCase):
         q2 = q1.transform(m)
 
         # use quaternion to rotate vector in each space
-        r1 = v1.transform(q1.to_matrix())
-        r2 = v2.transform(q2.to_matrix())
+        r1 = v1.transform(q1.as_matrix())
+        r2 = v2.transform(q2.as_matrix())
 
         # convert result in space 2 to space 1 for comparison
         r2_1 = r2.transform(m.inverse())
@@ -454,51 +413,12 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(r1.y, r2_1.y, delta=1e-10, msg='Transform failed [Y]')
         self.assertAlmostEqual(r1.z, r2_1.z, delta=1e-10, msg='Transform failed [Z]')
 
-    # def test_transform_vector(self):
-    #     """Testing method transform_vector()"""
-    #
-    #     q = Quaternion(0, 1, 0, 1).normalise()
-    #
-    #     v_result = q.transform_vector(Vector3D(1, 1, 1))
-    #     self.assertAlmostEqual(v_result.x, -1, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.y, 1, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.z, 1, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #
-    #     v_result = q.transform_vector(Vector3D(2, 3, 4))
-    #     self.assertAlmostEqual(v_result.x, -4, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.y, 3, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.z, 2, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #
-    #     q = Quaternion(0.5, 0.3, 0.1, 1).normalise()
-    #
-    #     v_result = q.transform_vector(Vector3D(1, 1, 1))
-    #     self.assertAlmostEqual(v_result.x, 0.8518518518518516, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.y, 1.4740740740740739, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.z, 0.3185185185185185, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #
-    #     v_result = q.transform_vector(Vector3D(2, 3, 4))
-    #     self.assertAlmostEqual(v_result.x, 1.3333333333333335, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.y, 5.133333333333333, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-    #     self.assertAlmostEqual(v_result.z, 0.9333333333333322, delta=1e-10,
-    #                            msg='Quaternion transform on a vector failed to produce the correct result.')
-
-    def test_to_matrix(self):
+    def test_as_matrix(self):
         """Test AffineMatrix3D generation from a quaternion"""
 
         message = 'Conversion of a Quaternion to AffineMatrix3D failed to produce the correct result.'
 
-        matrix = Quaternion(0.5, 0, 0, 0.5).to_matrix()
+        matrix = Quaternion(0.5, 0, 0, 0.5).as_matrix()
         answer = rotate_x(90)
 
         # TODO - replace this with a utility function e.g. _assert_matrix()
@@ -520,7 +440,7 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(matrix[3, 3], answer[3, 3], delta=1e-10, msg=message)
 
         # TODO - increase the resolution of this test by calculating quaternion more accurately
-        matrix = Quaternion(0.3826834, 0, 0, 0.923879).to_matrix()
+        matrix = Quaternion(0.3826834, 0, 0, 0.923879).as_matrix()
         answer = rotate_x(45)
 
         self.assertAlmostEqual(matrix[0, 0], answer[0, 0], delta=1e-6, msg=message)
@@ -599,198 +519,21 @@ class TestQuaternion(unittest.TestCase):
         self.assertAlmostEqual(answer.s, result.s, delta=1e-6,
                                msg='Extracting quaternion from AffineMatrix3D produced wrong result [S].')
 
-    # def test_rotation_delta(self):
-    #     """Test the rotation_delta() function."""
-    #
-    #     # reference vectors
-    #     x = Vector3D(1, 0, 0)
-    #     y = Vector3D(0, 1, 0)
-    #     z = Vector3D(0, 0, 1)
-    #
-    #     # rotate around x 90 degrees every second
-    #     omega = Vector3D(90, 0, 0)
-    #
-    #     # x should be un-effected by the rotations at all times
-    #     # z should return to its starting position over 4 seconds
-    #
-    #     # testing 0.5 seconds
-    #     q = rotation_delta(omega, 0.5)
-    #     xr = q.transform_vector(x)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     # testing 1 seconds
-    #     q = rotation_delta(omega, 1)
-    #     xr = q.transform_vector(x)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     # testing 2 seconds
-    #     q = rotation_delta(omega, 2)
-    #     xr = q.transform_vector(x)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, -1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     # testing 2.5 seconds
-    #     q = rotation_delta(omega, 2.5)
-    #     xr = q.transform_vector(x)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     # testing 4 seconds
-    #     q = rotation_delta(omega, 4)
-    #     xr = q.transform_vector(x)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     omega = Vector3D(0, 90, 0)
-    #     q = rotation_delta(omega, 0.5)
-    #     xr = q.transform_vector(x)
-    #     yr = q.transform_vector(y)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, 0.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     omega = Vector3D(0, 0, 90)
-    #     q = rotation_delta(omega, 0.5)
-    #     xr = q.transform_vector(x)
-    #     yr = q.transform_vector(y)
-    #     zr = q.transform_vector(z)
-    #     self.assertAlmostEqual(xr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.y, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(xr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(zr.z, 1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     omega = Vector3D(1/sqrt(2)*90, 0, 1/sqrt(2)*90)
-    #     q = rotation_delta(omega, 0.5)
-    #     yr = q.transform_vector(y)
-    #     self.assertAlmostEqual(yr.x, 0.5, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, -0.5, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     q = rotation_delta(omega, 1)
-    #     yr = q.transform_vector(y)
-    #     self.assertAlmostEqual(yr.x, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     q = rotation_delta(omega, 2)
-    #     yr = q.transform_vector(y)
-    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, -1, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     q = rotation_delta(omega, 3)
-    #     yr = q.transform_vector(y)
-    #     self.assertAlmostEqual(yr.x, -1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, 1/sqrt(2), delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #
-    #     q = rotation_delta(omega, 4)
-    #     yr = q.transform_vector(y)
-    #     self.assertAlmostEqual(yr.x, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.y, 1.0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
-    #     self.assertAlmostEqual(yr.z, 0, delta=1e-10,
-    #                            msg='Calculating the rotation delta from an angular velocity failed.')
+    def test_quaternion_to(self):
+        """Tests the calculation of a quaternion between two quaternions."""
+
+        q1 = Quaternion.from_axis_angle(Vector3D(1.0, 0.3, -0.1), 10)
+        q2 = Quaternion.from_axis_angle(Vector3D(0.2, 1.0, 1.0), 25)
+        d = q1.quaternion_to(q2)
+
+        # transform a vector with q1 + d and q2, both should result in the same answer
+        v = Vector3D(1, 3, 4)
+        r1 = v.transform(q1.as_matrix()).transform(d.as_matrix())
+        r2 = v.transform(q2.as_matrix())
+
+        self.assertAlmostEqual(r1.x, r2.x, delta=1e-10, msg='Rotation_to failed [X]')
+        self.assertAlmostEqual(r1.y, r2.y, delta=1e-10, msg='Rotation_to failed [Y]')
+        self.assertAlmostEqual(r1.z, r2.z, delta=1e-10, msg='Rotation_to failed [Z]')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Various quaternion improvements, resolves issues #327 and #339.

I've relabeled the q.transform(vector) method to q.transform_vector(vector) method as per @CnlPepper's suggestion. Although for me this feels a bit obvious, quaternions are by definition a class of transform and operate on vectors. 

This includes an example decomposition for ZYX (physics coordinates) Euler decomposition. Please have a check and if its appropriate I can expand the tests and add more coordinate cases.