### PR TITLE
Add 1D and 3D vector3d functions

### DIFF
--- a/raysect/core/math/function/vector3d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/__init__.pxd
@@ -29,6 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# from raysect.core.math.function.vector3d.function1d cimport *
+from raysect.core.math.function.vector3d.function1d cimport *
 from raysect.core.math.function.vector3d.function2d cimport *
 # from raysect.core.math.function.vector3d.function3d cimport *

--- a/raysect/core/math/function/vector3d/__init__.py
+++ b/raysect/core/math/function/vector3d/__init__.py
@@ -31,4 +31,4 @@
 
 from .function1d import *
 from .function2d import *
-# from .function3d import *
+from .function3d import *

--- a/raysect/core/math/function/vector3d/function1d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/function1d/__init__.pxd
@@ -29,6 +29,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.function.vector3d.function1d.utility cimport *

--- a/raysect/core/math/function/vector3d/function1d/__init__.py
+++ b/raysect/core/math/function/vector3d/function1d/__init__.py
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2020, Dr Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from .base import Function1D
+from .constant import Constant1D
+from .utility import *

--- a/raysect/core/math/function/vector3d/function1d/autowrap.pxd
+++ b/raysect/core/math/function/vector3d/function1d/autowrap.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+
+cdef class PythonFunction1D(Function1D):
+    cdef public object function
+
+cdef Function1D autowrap_function1d(object obj)

--- a/raysect/core/math/function/vector3d/function1d/autowrap.pyx
+++ b/raysect/core/math/function/vector3d/function1d/autowrap.pyx
@@ -1,0 +1,94 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.base cimport Function
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+from raysect.core.math.function.vector3d.function1d.constant cimport Constant1D
+
+
+cdef class PythonFunction1D(Function1D):
+    """
+    Wraps a python callable object with a Function1D object.
+
+    This class allows a python object to interact with cython code that requires
+    a Vector3DFunction1D object. The python object must implement __call__() expecting
+    two arguments.
+
+    This class is intended to be used to transparently wrap python objects that
+    are passed via constructors or methods into cython optimised code. It is not
+    intended that the users should need to directly interact with these wrapping
+    objects. Constructors and methods expecting a Vector3DFunction1D object should be
+    designed to accept a generic python object and then test that object to
+    determine if it is an instance of Vector3DFunction1D. If the object is not a
+    Vector3DFunction1D object it should be wrapped using this class for internal use.
+
+    See also: autowrap_vectorfunction1d()
+
+    :param object function: the python function to wrap, __call__() function must
+    be implemented on the object.
+    """
+    def __init__(self, object function):
+        self.function = function
+
+    cdef Vector3D evaluate(self, double x):
+        return self.function(x)
+
+
+cdef Function1D autowrap_function1d(object obj):
+    """
+    Automatically wraps the supplied python object in a PythonVector3DFunction1D or ConstantVector1D object.
+
+    If this function is passed a valid Vector3DFunction1D object, then the
+    Vector3DFunction1D object is simply returned without wrapping.
+
+    If this function is passed a Vector3D, a ConstantVector1D object is
+    returned.
+
+    This convenience function is provided to simplify the handling of
+    Vector3DFunction1D and python callable objects in constructors, functions and
+    setters.  """
+
+    if isinstance(obj, Function1D):
+        return <Function1D> obj
+    elif isinstance(obj, Function):
+        raise TypeError('A vector3d.Function1D object is required.')
+    try:
+        obj = Vector3D(*obj)
+    except (TypeError, ValueError):  # Not an iterable which can be converted to Vector3D
+        return PythonFunction1D(obj)
+    else:
+        return Constant1D(obj)
+
+
+def _autowrap_function1d(obj):
+    """Expose cython function for testing."""
+    return autowrap_function1d(obj)

--- a/raysect/core/math/function/vector3d/function1d/base.pxd
+++ b/raysect/core/math/function/vector3d/function1d/base.pxd
@@ -29,6 +29,58 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.base cimport Function
+from raysect.core.math.function.vector3d.base cimport Vector3DFunction
+from raysect.core.math.function.float cimport Function1D as FloatFunction1D
+
+
+cdef class Function1D(Vector3DFunction):
+    cdef Vector3D evaluate(self, double x)
+
+
+cdef class AddFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class SubtractFunction1D(Function1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class MultiplyFunction1D(Function1D):
+    cdef Function1D _function1
+    cdef FloatFunction1D _function2
+
+
+cdef class DivideFunction1D(Function1D):
+    cdef Function1D _function1
+    cdef FloatFunction1D _function2
+
+
+cdef class NegFunction1D(Function1D):
+    cdef Function1D _function
+
+
+cdef class EqualsFunction1D(FloatFunction1D):
+    cdef Function1D _function1, _function2
+
+
+cdef class NotEqualsFunction1D(FloatFunction1D):
+    cdef Function1D _function1, _function2
+
+
+cdef inline bint is_callable(object f):
+    """
+    Tests if an object is a python callable or a vector3d.Function1D object.
+
+    :param object f: Object to test.
+    :return: True if callable, False otherwise.
+    """
+    if isinstance(f, Function1D):
+        return True
+
+    # other function classes are incompatible
+    if isinstance(f, Function):
+        return False
+
+    return callable(f)

--- a/raysect/core/math/function/vector3d/function1d/base.pyx
+++ b/raysect/core/math/function/vector3d/function1d/base.pyx
@@ -1,0 +1,243 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numbers
+from cpython.object cimport Py_LT, Py_EQ, Py_GT, Py_LE, Py_NE, Py_GE
+cimport cython
+from libc.math cimport floor
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.float.function1d.base cimport is_callable as float_is_callable
+from raysect.core.math.function.float.function1d.autowrap cimport autowrap_function1d as autowrap_floatfunction1d
+from .autowrap cimport autowrap_function1d
+
+
+cdef class Function1D(Vector3DFunction):
+    """
+    Cython optimised class for representing an arbitrary 1D vector function.
+
+    Using __call__() in cython is slow. This class provides an overloadable
+    cython cdef evaluate() method which has much less overhead than a python
+    function call.
+
+    For use in cython code only, this class cannot be extended via python.
+
+    To create a new function object, inherit this class and implement the
+    evaluate() method. The new function object can then be used with any code
+    that accepts a function object returning a Vector3D.
+    """
+
+    cdef Vector3D evaluate(self, double x):
+        raise NotImplementedError("The evaluate() method has not been implemented.")
+
+    def __call__(self, double x):
+        """ Evaluate the function f(x)
+
+        :param float x: function parameter x
+        :rtype: float
+        """
+        return self.evaluate(x)
+
+    def __add__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if is_callable(b) or isinstance(b, Vector3D):
+                return AddFunction1D(a, b)
+        return NotImplemented
+
+    def __sub__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if is_callable(b) or isinstance(b, Vector3D):
+                return SubtractFunction1D(a, b)
+        return NotImplemented
+
+    def __mul__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if float_is_callable(b) or isinstance(b, numbers.Real):
+                return MultiplyFunction1D(a, b)
+        if is_callable(b) or isinstance(b, Vector3D):
+            if float_is_callable(a) or isinstance(a, numbers.Real):
+                return MultiplyFunction1D(b, a)
+        return NotImplemented
+
+    def __truediv__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if float_is_callable(b) or isinstance(b, numbers.Real):
+                return DivideFunction1D(a, b)
+        return NotImplemented
+
+    def __neg__(self):
+        return NegFunction1D(self)
+
+    def __richcmp__(self, object other, int op):
+        if is_callable(other) or isinstance(other, Vector3D):
+            if op == Py_EQ:
+                return EqualsFunction1D(self, other)
+            if op == Py_NE:
+                return NotEqualsFunction1D(self, other)
+        return NotImplemented
+
+
+cdef class AddFunction1D(Function1D):
+    """
+    A vector3d.Function1D class that implements the addition of the results of two vector3d.Function1D objects: f1() + f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __add__() call on a
+    Function1D object.
+
+    :param object function1: A vector3d.Function1D object or Python callable.
+    :param object function2: A vector3d.Function1D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_function1d(function2)
+
+    cdef Vector3D evaluate(self, double x):
+        return self._function1.evaluate(x).add(self._function2.evaluate(x))
+
+
+cdef class SubtractFunction1D(Function1D):
+    """
+    A vector3d.Function1D class that implements the subtraction of the results of two vector3d.Function1D objects: f1() - f2()
+
+    This class is not intended to be used directly, but rather returned as the result of a __sub__() call on a
+    Function1D object.
+
+    :param object function1: A vector3d.Function1D object or Python callable.
+    :param object function2: A vector3d.Function1D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_function1d(function2)
+
+    cdef Vector3D evaluate(self, double x):
+        return self._function1.evaluate(x).sub(self._function2.evaluate(x))
+
+
+cdef class MultiplyFunction1D(Function1D):
+    """
+    A vector3d.Function1D class that implements the multiplication of the result of a vector3d.Function1D object with the result of a float.Function1D object scalar: f1() * f2().
+
+    This class is not intended to be used directly, but rather returned as the result of a __sub__() call on a
+    vector3d.Function1D object.
+
+    :param object function1: A vector3d.Function1D object or Python callable returning a Vector3D.
+    :param object function2: A float.Function1D object or Python callable returning a double.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_floatfunction1d(function2)
+
+    cdef Vector3D evaluate(self, double x):
+        return self._function1.evaluate(x).mul(self._function2.evaluate(x))
+
+
+cdef class DivideFunction1D(Function1D):
+    """
+    A vector3d.Function1D class that implements the division of the results of a vector3d.Function1D object and a float.Function1D object: f1() / f2()
+
+    This class is not intended to be used directly, but rather returned as the result of a __truediv__() call on a
+    vector3d.Function1D object.
+
+    :param object function1: A vector3d.Function1D object or Python callable returning a Vector3D.
+    :param object function2: A float.Function1D object or Python callable returning a double.
+    """
+
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_floatfunction1d(function2)
+
+    @cython.cdivision(True)
+    cdef Vector3D evaluate(self, double x):
+        cdef double denominator = self._function2.evaluate(x)
+        if denominator == 0.0:
+            raise ZeroDivisionError("Function used as the denominator of the division returned a zero value.")
+        return self._function1.evaluate(x).div(denominator)
+
+
+cdef class NegFunction1D(Function1D):
+    """
+    A vector3d.Function1D class that implements the negation of the result of a vector3d.Function1D: -f().
+
+    This class is not intended to be used directly, but rather returned as the result of a __neg__() call on a
+    vector3d.Function1D object.
+
+    :param object function: A vector3d.Function1D object or Python callable.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function1d(function)
+
+    cdef Vector3D evaluate(self, double x):
+        return self._function.evaluate(x).neg()
+
+
+cdef class EqualsFunction1D(FloatFunction1D):
+    """
+    A float.Function1D class that tests the equality of the results of two vector3d.Function1D objects: f1() == f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __eq__() call on a
+    vector3d.Function1D object.
+
+    N.B. This is a float.Function1D class, so returns a double rather than a Vector3D.
+
+    :param object function1: A vector3d.Function1D object or Python callable.
+    :param object function2: A vector3d.Function1D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_function1d(function2)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        cdef Vector3D v1, v2
+        v1 = self._function1.evaluate(x)
+        v2 = self._function2.evaluate(x)
+        return 1.0 if (v1.x == v2.x and v1.y == v2.y and v1.z == v2.z) else 0.0
+
+
+cdef class NotEqualsFunction1D(FloatFunction1D):
+    """
+    A float.Function1D class that tests the inequality of the results of two vector3d.Function1D objects: f1() != f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __neq__() call on a
+    vector3d.Function1D object.
+
+    N.B. This is a float.Function1D class, so returns a double rather than a Vector3D.
+
+    :param object function1: A vector3d.Function1D object or Python callable.
+    :param object function2: A vector3d.Function1D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function1d(function1)
+        self._function2 = autowrap_function1d(function2)
+
+    cdef double evaluate(self, double x) except? -1e999:
+        cdef Vector3D v1, v2
+        v1 = self._function1.evaluate(x)
+        v2 = self._function2.evaluate(x)
+        return 0.0 if (v1.x == v2.x and v1.y == v2.y and v1.z == v2.z) else 1.0

--- a/raysect/core/math/function/vector3d/function1d/constant.pxd
+++ b/raysect/core/math/function/vector3d/function1d/constant.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+
+
+cdef class Constant1D(Function1D):
+    cdef Vector3D _value

--- a/raysect/core/math/function/vector3d/function1d/constant.pyx
+++ b/raysect/core/math/function/vector3d/function1d/constant.pyx
@@ -29,6 +29,33 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+
+
+cdef class Constant1D(Function1D):
+    """
+    Wraps a Vector3D object with a Function1D object.
+
+    This class allows a constant vector object to interact with cython code that
+    requires a vector3d.Function1D object. The object must be convertible to a
+    Vector3D. The value of the Vector3D constant will be returned independent of
+    the arguments the function is called with.
+
+    This class is intended to be used to transparently wrap python objects that
+    are passed via constructors or methods into cython optimised code. It is not
+    intended that the users should need to directly interact with these wrapping
+    objects. Constructors and methods expecting a vector3d.function1D object should be
+    designed to accept a generic python object and then test that object to
+    determine if it is an instance of vector3d.Function1D. If the object is not a
+    vector3d.Function1D object it should be wrapped using this class for internal use.
+
+    See also: float3d.autowrap_function1d()
+
+    :param object value: the constant value, convertible to Vector3D, to return when called.
+    """
+    def __init__(self, object value):
+        self._value = Vector3D(*value)
+
+    cdef Vector3D evaluate(self, double x):
+        return self._value

--- a/raysect/core/math/function/vector3d/function1d/tests/__init__.py
+++ b/raysect/core/math/function/vector3d/function1d/tests/__init__.py
@@ -1,0 +1,4 @@
+from .test_base import *
+from .test_autowrap import *
+from .test_constant import *
+from .test_float_to_vector3d import *

--- a/raysect/core/math/function/vector3d/function1d/tests/test_autowrap.py
+++ b/raysect/core/math/function/vector3d/function1d/tests/test_autowrap.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,29 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+"""
+Unit tests for the autowrap_1d function
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.vector3d.function1d.autowrap import _autowrap_function1d
+from raysect.core.math.function.vector3d.function1d.autowrap import PythonFunction1D
+from raysect.core.math.function.vector3d.function1d.constant import Constant1D
+
+class TestAutowrap1D(unittest.TestCase):
+
+    def test_constant_vector(self):
+        function = _autowrap_function1d(Vector3D(3.0, 4.0, 5.0))
+        self.assertIsInstance(function, Constant1D,
+                              "Autowrapped Vector3D is not a vector3d.Constant1D.")
+
+    def test_constant_iterable(self):
+        function = _autowrap_function1d([3, 4, 5.0])
+        self.assertIsInstance(function, Constant1D,
+                              "Autowrapped iterable is not a vector3d.Constant1D.")
+
+    def test_python_function(self):
+        function = _autowrap_function1d(lambda x: Vector3D(x, 2 * x, x + 3))
+        self.assertIsInstance(function, PythonFunction1D,
+                              "Autowrapped function is not a vector3d.PythonFunction1D.")

--- a/raysect/core/math/function/vector3d/function1d/tests/test_base.py
+++ b/raysect/core/math/function/vector3d/function1d/tests/test_base.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Unit tests for the vector3d.Function1D class.
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.float.function1d.autowrap import PythonFunction1D as PythonFloatFunction1D
+from raysect.core.math.function.vector3d.function1d.autowrap import PythonFunction1D as PythonVector3DFunction1D
+
+# TODO: expand tests to cover the cython interface
+class TestFunction1D(unittest.TestCase):
+
+    def setUp(self):
+
+        self.refv1 = lambda x: Vector3D(10 * x + 5, 10 * x - 5 , x)
+        self.refv2 = lambda x: Vector3D(x * x + 25, x * x - 25, x * 5)
+
+        self.vf1 = PythonVector3DFunction1D(self.refv1)
+        self.vf2 = PythonVector3DFunction1D(self.refv2)
+
+        self.ref1 = lambda x: 10 * x + 5
+        self.ref2 = lambda x: x * x
+
+        self.f1 = PythonFloatFunction1D(self.ref1)
+        self.f2 = PythonFloatFunction1D(self.ref2)
+
+    def test_call(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            self.assertEqual(self.vf1(x), self.refv1(x), "vector3d.Function1D call did not match reference function value.")
+
+    def test_negate(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = -self.vf1
+        for x in v:
+            self.assertEqual(r(x), -self.refv1(x), "vector3d.Function1D negate did not match reference function value.")
+
+    def test_add_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        c1 = Vector3D(3, 4, 5)
+        c2 = Vector3D(5, 12, 13)
+        r1 = c1 + self.vf1
+        r2 = self.vf1 + c2
+        for x in v:
+            self.assertEqual(r1(x), c1 + self.refv1(x), "vector3d.Function1D add Vector3D (V + vf()) did not match reference function value.")
+            self.assertEqual(r2(x), self.refv1(x) + c2, "vector3d.Function1D add Vector3D (vf() + V) did not match reference function value.")
+
+    def test_sub_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        c1 = Vector3D(3, 4, 5)
+        c2 = Vector3D(5, 12, 13)
+        r1 = c1 - self.vf1
+        r2 = self.vf1 - c2
+        for x in v:
+            self.assertEqual(r1(x), c1 - self.refv1(x), "vector3d.Function1D subtract Vector3D (V - vf()) did not match reference function value.")
+            self.assertEqual(r2(x), self.refv1(x) - c2, "vector3d.Function1D subtract Vector3D (vf() - V) did not match reference function value.")
+
+    def test_mul_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = self.vf1 * -7.8
+        for x in v:
+            self.assertEqual(r(x), self.refv1(x) * -7.8, "vector3d.Function1D multiply Vector3D (vf() * V) did not match reference function value.")
+
+    def test_div_vector(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
+        r = self.vf1 / -7.8
+        for x in v:
+            self.assertEqual(r(x), self.refv1(x) / -7.8, "vector3d.Function1D divide Vector3D (vf() / V) did not match reference function value.")
+
+        with self.assertRaises(TypeError, msg="TypeError not raised when dividing Vector3D by function."):
+            r = 5 / self.vf1
+
+    def test_richcmp_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.refv1(x)
+            not_ref_value = ref_value + Vector3D(*[ref + abs(ref) + 1 for ref in ref_value])
+            self.assertEqual(
+                (self.vf1 == ref_value)(x), 1.0,
+                msg="vector3d.Function1D equals Vector3D (vf() == V) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value == self.vf1)(x), 1.0,
+                msg="Vector3D equals vector3d.Function1D(V == vf()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 == not_ref_value)(x), 0.0,
+                msg="vector3d.Function1D equals Vector3D (vf() == V) did not return false when it should."
+            )
+            self.assertEqual(
+                (not_ref_value == self.vf1)(x), 0.0,
+                msg="Vector3D equals vector3d.Function1D(V == vf()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != not_ref_value)(x), 1.0,
+                msg="vector3d.Function1D not equals Vector3D (vf() != V) did not return true when it should."
+            )
+            self.assertEqual(
+                (not_ref_value != self.vf1)(x), 1.0,
+                msg="Vector3D not equals vector3d.Function1D(V != vf()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != ref_value)(x), 0.0,
+                msg="vector3d.Function1D not equals Vector3D (vf() != V) did not return false when it should."
+            )
+            self.assertEqual(
+                (ref_value != self.vf1)(x), 0.0,
+                msg="Vector3D not equals vector3d.Function1D(V != vf()) did not return false when it should."
+            )
+
+    def test_add_function1d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 + self.vf2
+        r2 = self.refv1 + self.vf2
+        r3 = self.vf1 + self.refv2
+        for x in v:
+            self.assertEqual(r1(x), self.refv1(x) + self.refv2(x), "vector3d.Function1D add function (vf1() + vf2()) did not match reference function value.")
+            self.assertEqual(r2(x), self.refv1(x) + self.refv2(x), "vector3d.Function1D add function (p1() + vf2()) did not match reference function value.")
+            self.assertEqual(r3(x), self.refv1(x) + self.refv2(x), "vector3d.Function1D add function (vf1() + p2()) did not match reference function value.")
+
+    def test_sub_function1d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = self.vf1 - self.vf2
+        r2 = self.refv1 - self.vf2
+        r3 = self.vf1 - self.refv2
+        for x in v:
+            self.assertEqual(r(x), self.refv1(x) - self.refv2(x), "vector3d.Function1D subtract function (vf1() - vf2()) did not match reference function value.")
+            self.assertEqual(r2(x), self.refv1(x) - self.refv2(x), "vector3d.Function1D subtract function (p1() - vf2()) did not match reference function value.")
+            self.assertEqual(r3(x), self.refv1(x) - self.refv2(x), "vector3d.Function1D subtract function (vf1() - p2()) did not match reference function value.")
+
+    def test_mul_function1d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 * self.f2
+        # No r2 = self.refv1 * self.f2, as p1() * f2() is treated as PythonFunction1D * Function1D
+        r2 = self.f1 * self.vf2
+        r3 = self.vf1 * self.ref2
+        for x in v:
+            self.assertEqual(r1(x), self.refv1(x) * self.ref2(x), "vector3d.Function1D multiply function (vf1() * f2()) did not match reference function value.")
+            self.assertEqual(r2(x), self.ref1(x) * self.refv2(x), "vector3d.Function1D multiply function (f1() * vf2()) did not match reference function value.")
+            self.assertEqual(r3(x), self.refv1(x) * self.ref2(x), "vector3d.Function1D multiply function (vf1() * p2()) did not match reference function value.")
+
+    def test_div_function1d(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 / self.f2
+        # No r2 = self.refv1 / self.f2, as p1() / f2() is treated as PythonFunction1D / Function1D
+        r3 = self.vf1 / self.ref2
+        for x in v:
+            self.assertEqual(r1(x), self.refv1(x) / self.ref2(x), msg="vector3d.Function1D divide function (vf1() / f2()) did not match reference function value.")
+            self.assertEqual(r3(x), self.refv1(x) / self.ref2(x), msg="vector3d.Function1D divide function (vf1() / p2()) did not match reference function value.")
+
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
+            r1(0)
+
+    def test_richcmp_function1d_callable(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.refv1
+
+            def not_ref_value(x):
+                ref = self.refv1(x)
+                return ref + Vector3D(*[abs(r) + 1 for r in ref])
+
+            self.assertEqual(
+                (self.vf1 == ref_value)(x), 1.0,
+                msg="vector3d.Function1D equals callable (vf1() == f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 == not_ref_value)(x), 0.0,
+                msg="vector3d.Function1D equals callable (vf1() == f2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != not_ref_value)(x), 1.0,
+                msg="vector3d.Function1D not equals callable (vf1() != f2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != ref_value)(x), 0.0,
+                msg="vector3d.Function1D not equals callable (vf1() != f2()) did not return false when it should."
+            )
+
+    def test_richcmp_callable_function1d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.refv1
+
+            def not_ref_value(x):
+                ref = self.refv1(x)
+                return ref + Vector3D(*[abs(r) + 1 for r in ref])
+
+            self.assertEqual(
+                (ref_value == self.vf1)(x), 1.0,
+                msg="Callable equals vector3d.Function1D(f1() == vf2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (not_ref_value == self.vf1)(x), 0.0,
+                msg="Callable equals vector3d.Function1D(f1() == vf2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (not_ref_value != self.vf1)(x), 1.0,
+                msg="Callable not equals vector3d.Function1D(f1() != vf2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (ref_value != self.vf1)(x), 0.0,
+                msg="Callable not equals vector3d.Function1D(f1() != vf2()) did not return false when it should."
+            )
+
+    def test_richcmp_function1d_function1d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            ref_value = self.vf1
+            shift = Vector3D(*[abs(r) + 1 for r in self.refv1(x)])
+            not_ref_value = self.vf1 + shift
+            self.assertEqual(
+                (self.vf1 == ref_value)(x), 1.0,
+                msg="vector3d.Function1D equals vector3d.Function1D (vf1() == vf2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 == not_ref_value)(x), 0.0,
+                msg="vector3d.Function1D equals vector3d.Function1D (vf1() == vf2()) did not return false when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != not_ref_value)(x), 1.0,
+                msg="vector3d.Function1D not equals vector3d.Function1D (vf1() != vf2()) did not return true when it should."
+            )
+            self.assertEqual(
+                (self.vf1 != ref_value)(x), 0.0,
+                msg="vector3d.Function1D not equals vector3d.Function1D (vf1() != vf2()) did not return false when it should."
+            )

--- a/raysect/core/math/function/vector3d/function1d/tests/test_constant.py
+++ b/raysect/core/math/function/vector3d/function1d/tests/test_constant.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+"""
+Unit tests for the Constant1D class.
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.vector3d.function1d.constant import Constant1D
+
+# TODO: expand tests to cover the cython interface
+class TestConstant1D(unittest.TestCase):
+
+    def test_constant(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    vector = Vector3D(x, y, z)
+                    constant = Constant1D(vector)
+                    self.assertEqual(constant(500), vector,
+                                     "vector3d.Constant1D call did not match reference value.")

--- a/raysect/core/math/function/vector3d/function1d/tests/test_float_to_vector3d.py
+++ b/raysect/core/math/function/vector3d/function1d/tests/test_float_to_vector3d.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,27 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+"""
+Unit tests for the Constant1D class.
+"""
+
+from math import sin
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.float import Arg1D, Sin1D
+from raysect.core.math.function.vector3d import FloatToVector3DFunction1D
+
+# TODO: expand tests to cover the cython interface
+class TestFloatToVector1D(unittest.TestCase):
+
+    def test_scalar_to_vector(self):
+        vx = 1  # Will be auto-wrapped to Constant1D
+        vy = Arg1D()
+        vz = Sin1D(Arg1D('x'))
+        fv = FloatToVector3DFunction1D(vx, vy, vz)
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            expected = Vector3D(1, x, sin(x))
+            actual = fv(x)
+            self.assertEqual(actual, expected,
+                             "FloatToVector3DFunction1D call did not match reference value.")

--- a/raysect/core/math/function/vector3d/function1d/utility.pxd
+++ b/raysect/core/math/function/vector3d/function1d/utility.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.function.float.function1d.base cimport Function1D as FloatFunction1D
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+
+
+cdef class FloatToVector3DFunction1D(Function1D):
+    cdef FloatFunction1D _x, _y, _z

--- a/raysect/core/math/function/vector3d/function1d/utility.pyx
+++ b/raysect/core/math/function/vector3d/function1d/utility.pyx
@@ -29,6 +29,45 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .function1d import *
-from .function2d import *
-# from .function3d import *
+from raysect.core.math.vector cimport Vector3D, new_vector3d
+from raysect.core.math.function.float cimport autowrap_function1d as autowrap_floatfunction1d
+from .base cimport Function1D
+
+
+
+cdef class FloatToVector3DFunction1D(Function1D):
+    """
+    Combines three float.Function1D objects to produce a vector3d.Function1D.
+
+    The three float.Function1D objects correspond to the x, y and z components
+    of the resulting vector object.
+
+    :param float.Function1D x_function: the Vx(x) 1d function.
+    :param float.Function1D y_function: the Vy(x) 1d function.
+    :param float.Function1D z_function: the Vz(x) 1d function.
+
+    .. code-block:: pycon
+
+       >>> from raysect.core.math.function.float import Sqrt1D, Exp1D, Arg1D
+       >>> from raysect.core.math.function.vector3d import FloatToVector3DFunction1D
+       >>>
+       >>> vx = 1  # Will be auto-wrapped to Constant1D(1)
+       >>> vy = Arg1D('y')
+       >>> vz = Sqrt1D(Arg1D('x'))
+       >>>
+       >>> fv = FloatToVector3DFunction1D(vx, vy, vz)
+       >>> fv(4.0, 6.2)
+       Vector3D(1.0, 6.2, 2.0)
+    """
+
+    def __init__(self, object x_function, object y_function, object z_function):
+        self._x = autowrap_floatfunction1d(x_function)
+        self._y = autowrap_floatfunction1d(y_function)
+        self._z = autowrap_floatfunction1d(z_function)
+
+    cdef Vector3D evaluate(self, double x):
+        cdef double vx, vy, vz
+        vx = self._x.evaluate(x)
+        vy = self._y.evaluate(x)
+        vz = self._z.evaluate(x)
+        return new_vector3d(vx, vy, vz)

--- a/raysect/core/math/function/vector3d/function3d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/function3d/__init__.pxd
@@ -29,6 +29,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.function.vector3d.function3d.utility cimport *

--- a/raysect/core/math/function/vector3d/function3d/__init__.py
+++ b/raysect/core/math/function/vector3d/function3d/__init__.py
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# Copyright (c) 2014-2020, Dr Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from .base import Function3D
+from .constant import Constant3D
+from .utility import *

--- a/raysect/core/math/function/vector3d/function3d/autowrap.pxd
+++ b/raysect/core/math/function/vector3d/function3d/autowrap.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+
+cdef class PythonFunction3D(Function3D):
+    cdef public object function
+
+cdef Function3D autowrap_function3d(object obj)

--- a/raysect/core/math/function/vector3d/function3d/autowrap.pyx
+++ b/raysect/core/math/function/vector3d/function3d/autowrap.pyx
@@ -1,0 +1,94 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.base cimport Function
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+from raysect.core.math.function.vector3d.function3d.constant cimport Constant3D
+
+
+cdef class PythonFunction3D(Function3D):
+    """
+    Wraps a python callable object with a Function3D object.
+
+    This class allows a python object to interact with cython code that requires
+    a Vector3DFunction3D object. The python object must implement __call__() expecting
+    two arguments.
+
+    This class is intended to be used to transparently wrap python objects that
+    are passed via constructors or methods into cython optimised code. It is not
+    intended that the users should need to directly interact with these wrapping
+    objects. Constructors and methods expecting a Vector3DFunction3D object should be
+    designed to accept a generic python object and then test that object to
+    determine if it is an instance of Vector3DFunction3D. If the object is not a
+    Vector3DFunction3D object it should be wrapped using this class for internal use.
+
+    See also: autowrap_vectorfunction3d()
+
+    :param object function: the python function to wrap, __call__() function must
+    be implemented on the object.
+    """
+    def __init__(self, object function):
+        self.function = function
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self.function(x, y, z)
+
+
+cdef Function3D autowrap_function3d(object obj):
+    """
+    Automatically wraps the supplied python object in a PythonVector3DFunction3D or ConstantVector3D object.
+
+    If this function is passed a valid Vector3DFunction3D object, then the
+    Vector3DFunction3D object is simply returned without wrapping.
+
+    If this function is passed a Vector3D, a ConstantVector3D object is
+    returned.
+
+    This convenience function is provided to simplify the handling of
+    Vector3DFunction3D and python callable objects in constructors, functions and
+    setters.  """
+
+    if isinstance(obj, Function3D):
+        return <Function3D> obj
+    elif isinstance(obj, Function):
+        raise TypeError('A vector3d.Function1D object is required.')
+    try:
+        obj = Vector3D(*obj)
+    except (TypeError, ValueError):  # Not an iterable which can be converted to Vector3D
+        return PythonFunction3D(obj)
+    else:
+        return Constant3D(obj)
+
+
+def _autowrap_function3d(obj):
+    """Expose cython function for testing."""
+    return autowrap_function3d(obj)

--- a/raysect/core/math/function/vector3d/function3d/base.pxd
+++ b/raysect/core/math/function/vector3d/function3d/base.pxd
@@ -29,6 +29,58 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.base cimport Function
+from raysect.core.math.function.vector3d.base cimport Vector3DFunction
+from raysect.core.math.function.float cimport Function3D as FloatFunction3D
+
+
+cdef class Function3D(Vector3DFunction):
+    cdef Vector3D evaluate(self, double x, double y, double z)
+
+
+cdef class AddFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class SubtractFunction3D(Function3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class MultiplyFunction3D(Function3D):
+    cdef Function3D _function1
+    cdef FloatFunction3D _function2
+
+
+cdef class DivideFunction3D(Function3D):
+    cdef Function3D _function1
+    cdef FloatFunction3D _function2
+
+
+cdef class NegFunction3D(Function3D):
+    cdef Function3D _function
+
+
+cdef class EqualsFunction3D(FloatFunction3D):
+    cdef Function3D _function1, _function2
+
+
+cdef class NotEqualsFunction3D(FloatFunction3D):
+    cdef Function3D _function1, _function2
+
+
+cdef inline bint is_callable(object f):
+    """
+    Tests if an object is a python callable or a vector3d.Function3D object.
+
+    :param object f: Object to test.
+    :return: True if callable, False otherwise.
+    """
+    if isinstance(f, Function3D):
+        return True
+
+    # other function classes are incompatible
+    if isinstance(f, Function):
+        return False
+
+    return callable(f)

--- a/raysect/core/math/function/vector3d/function3d/base.pyx
+++ b/raysect/core/math/function/vector3d/function3d/base.pyx
@@ -1,0 +1,244 @@
+# cython: language_level=3
+
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numbers
+from cpython.object cimport Py_LT, Py_EQ, Py_GT, Py_LE, Py_NE, Py_GE
+cimport cython
+from libc.math cimport floor
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.float.function3d.base cimport is_callable as float_is_callable
+from raysect.core.math.function.float.function3d.autowrap cimport autowrap_function3d as autowrap_floatfunction3d
+from .autowrap cimport autowrap_function3d
+
+
+cdef class Function3D(Vector3DFunction):
+    """
+    Cython optimised class for representing an arbitrary 3D vector function.
+
+    Using __call__() in cython is slow. This class provides an overloadable
+    cython cdef evaluate() method which has much less overhead than a python
+    function call.
+
+    For use in cython code only, this class cannot be extended via python.
+
+    To create a new function object, inherit this class and implement the
+    evaluate() method. The new function object can then be used with any code
+    that accepts a function object returning a Vector3D.
+    """
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        raise NotImplementedError("The evaluate() method has not been implemented.")
+
+    def __call__(self, double x, double y, double z):
+        """ Evaluate the function f(x, y, z)
+
+        :param float x: function parameter x
+        :param float y: function parameter y
+        :rtype: float
+        """
+        return self.evaluate(x, y, z)
+
+    def __add__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if is_callable(b) or isinstance(b, Vector3D):
+                return AddFunction3D(a, b)
+        return NotImplemented
+
+    def __sub__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if is_callable(b) or isinstance(b, Vector3D):
+                return SubtractFunction3D(a, b)
+        return NotImplemented
+
+    def __mul__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if float_is_callable(b) or isinstance(b, numbers.Real):
+                return MultiplyFunction3D(a, b)
+        if is_callable(b) or isinstance(b, Vector3D):
+            if float_is_callable(a) or isinstance(a, numbers.Real):
+                return MultiplyFunction3D(b, a)
+        return NotImplemented
+
+    def __truediv__(object a, object b):
+        if is_callable(a) or isinstance(a, Vector3D):
+            if float_is_callable(b) or isinstance(b, numbers.Real):
+                return DivideFunction3D(a, b)
+        return NotImplemented
+
+    def __neg__(self):
+        return NegFunction3D(self)
+
+    def __richcmp__(self, object other, int op):
+        if is_callable(other) or isinstance(other, Vector3D):
+            if op == Py_EQ:
+                return EqualsFunction3D(self, other)
+            if op == Py_NE:
+                return NotEqualsFunction3D(self, other)
+        return NotImplemented
+
+
+cdef class AddFunction3D(Function3D):
+    """
+    A vector3d.Function3D class that implements the addition of the results of two vector3d.Function3D objects: f1() + f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __add__() call on a
+    Function3D object.
+
+    :param object function1: A vector3d.Function3D object or Python callable.
+    :param object function2: A vector3d.Function3D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_function3d(function2)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self._function1.evaluate(x, y, z).add(self._function2.evaluate(x, y, z))
+
+
+cdef class SubtractFunction3D(Function3D):
+    """
+    A vector3d.Function3D class that implements the subtraction of the results of two vector3d.Function3D objects: f1() - f2()
+
+    This class is not intended to be used directly, but rather returned as the result of a __sub__() call on a
+    Function3D object.
+
+    :param object function1: A vector3d.Function3D object or Python callable.
+    :param object function2: A vector3d.Function3D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_function3d(function2)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self._function1.evaluate(x, y, z).sub(self._function2.evaluate(x, y, z))
+
+
+cdef class MultiplyFunction3D(Function3D):
+    """
+    A vector3d.Function3D class that implements the multiplication of the result of a vector3d.Function3D object with the result of a float.Function3D object scalar: f1() * f2().
+
+    This class is not intended to be used directly, but rather returned as the result of a __sub__() call on a
+    vector3d.Function3D object.
+
+    :param object function1: A vector3d.Function3D object or Python callable returning a Vector3D.
+    :param object function2: A float.Function3D object or Python callable returning a double.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_floatfunction3d(function2)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self._function1.evaluate(x, y, z).mul(self._function2.evaluate(x, y, z))
+
+
+cdef class DivideFunction3D(Function3D):
+    """
+    A vector3d.Function3D class that implements the division of the results of a vector3d.Function3D object and a float.Function3D object: f1() / f2()
+
+    This class is not intended to be used directly, but rather returned as the result of a __truediv__() call on a
+    vector3d.Function3D object.
+
+    :param object function1: A vector3d.Function3D object or Python callable returning a Vector3D.
+    :param object function2: A float.Function3D object or Python callable returning a double.
+    """
+
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_floatfunction3d(function2)
+
+    @cython.cdivision(True)
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        cdef double denominator = self._function2.evaluate(x, y, z)
+        if denominator == 0.0:
+            raise ZeroDivisionError("Function used as the denominator of the division returned a zero value.")
+        return self._function1.evaluate(x, y, z).div(denominator)
+
+
+cdef class NegFunction3D(Function3D):
+    """
+    A vector3d.Function3D class that implements the negation of the result of a vector3d.Function3D: -f().
+
+    This class is not intended to be used directly, but rather returned as the result of a __neg__() call on a
+    vector3d.Function3D object.
+
+    :param object function: A vector3d.Function3D object or Python callable.
+    """
+    def __init__(self, object function):
+        self._function = autowrap_function3d(function)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self._function.evaluate(x, y, z).neg()
+
+
+cdef class EqualsFunction3D(FloatFunction3D):
+    """
+    A float.Function3D class that tests the equality of the results of two vector3d.Function3D objects: f1() == f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __eq__() call on a
+    vector3d.Function3D object.
+
+    N.B. This is a float.Function3D class, so returns a double rather than a Vector3D.
+
+    :param object function1: A vector3d.Function3D object or Python callable.
+    :param object function2: A vector3d.Function3D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_function3d(function2)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        cdef Vector3D v1, v2
+        v1 = self._function1.evaluate(x, y, z)
+        v2 = self._function2.evaluate(x, y, z)
+        return 1.0 if (v1.x == v2.x and v1.y == v2.y and v1.z == v2.z) else 0.0
+
+
+cdef class NotEqualsFunction3D(FloatFunction3D):
+    """
+    A float.Function3D class that tests the inequality of the results of two vector3d.Function3D objects: f1() != f2()
+
+    This class is not intended to be used directly, but rather returned as the result of an __neq__() call on a
+    vector3d.Function3D object.
+
+    N.B. This is a float.Function3D class, so returns a double rather than a Vector3D.
+
+    :param object function1: A vector3d.Function3D object or Python callable.
+    :param object function2: A vector3d.Function3D object or Python callable.
+    """
+    def __init__(self, object function1, object function2):
+        self._function1 = autowrap_function3d(function1)
+        self._function2 = autowrap_function3d(function2)
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        cdef Vector3D v1, v2
+        v1 = self._function1.evaluate(x, y, z)
+        v2 = self._function2.evaluate(x, y, z)
+        return 0.0 if (v1.x == v2.x and v1.y == v2.y and v1.z == v2.z) else 1.0

--- a/raysect/core/math/function/vector3d/function3d/constant.pxd
+++ b/raysect/core/math/function/vector3d/function3d/constant.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+
+
+cdef class Constant3D(Function3D):
+    cdef Vector3D _value

--- a/raysect/core/math/function/vector3d/function3d/constant.pyx
+++ b/raysect/core/math/function/vector3d/function3d/constant.pyx
@@ -29,6 +29,33 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.vector cimport Vector3D
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+
+
+cdef class Constant3D(Function3D):
+    """
+    Wraps a Vector3D object with a Function3D object.
+
+    This class allows a constant vector object to interact with cython code that
+    requires a vector3d.Function3D object. The object must be convertible to a
+    Vector3D. The value of the Vector3D constant will be returned independent of
+    the arguments the function is called with.
+
+    This class is intended to be used to transparently wrap python objects that
+    are passed via constructors or methods into cython optimised code. It is not
+    intended that the users should need to directly interact with these wrapping
+    objects. Constructors and methods expecting a vector3d.function3D object should be
+    designed to accept a generic python object and then test that object to
+    determine if it is an instance of vector3d.Function3D. If the object is not a
+    vector3d.Function3D object it should be wrapped using this class for internal use.
+
+    See also: float3d.autowrap_function3d()
+
+    :param object value: the constant value, convertible to Vector3D, to return when called.
+    """
+    def __init__(self, object value):
+        self._value = Vector3D(*value)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        return self._value

--- a/raysect/core/math/function/vector3d/function3d/tests/__init__.py
+++ b/raysect/core/math/function/vector3d/function3d/tests/__init__.py
@@ -1,0 +1,4 @@
+from .test_base import *
+from .test_autowrap import *
+from .test_constant import *
+from .test_float_to_vector3d import *

--- a/raysect/core/math/function/vector3d/function3d/tests/test_autowrap.py
+++ b/raysect/core/math/function/vector3d/function3d/tests/test_autowrap.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,29 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+"""
+Unit tests for the autowrap_3d function
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.vector3d.function3d.autowrap import _autowrap_function3d
+from raysect.core.math.function.vector3d.function3d.autowrap import PythonFunction3D
+from raysect.core.math.function.vector3d.function3d.constant import Constant3D
+
+class TestAutowrap3D(unittest.TestCase):
+
+    def test_constant_vector(self):
+        function = _autowrap_function3d(Vector3D(3.0, 4.0, 5.0))
+        self.assertIsInstance(function, Constant3D,
+                              "Autowrapped Vector3D is not a vector3d.Constant3D.")
+
+    def test_constant_iterable(self):
+        function = _autowrap_function3d([3, 4, 5.0])
+        self.assertIsInstance(function, Constant3D,
+                              "Autowrapped iterable is not a vector3d.Constant3D.")
+
+    def test_python_function(self):
+        function = _autowrap_function3d(lambda x, y: Vector3D(x, y, x + y))
+        self.assertIsInstance(function, PythonFunction3D,
+                              "Autowrapped function is not a vector3d.PythonFunction3D.")

--- a/raysect/core/math/function/vector3d/function3d/tests/test_base.py
+++ b/raysect/core/math/function/vector3d/function3d/tests/test_base.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of the Raysect Project nor the names of its
+#        contributors may be used to endorse or promote products derived from
+#        this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Unit tests for the vector3d.Function3D class.
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.float.function3d.autowrap import PythonFunction3D as PythonFloatFunction3D
+from raysect.core.math.function.vector3d.function3d.autowrap import PythonFunction3D as PythonVector3DFunction3D
+
+# TODO: expand tests to cover the cython interface
+class TestFunction3D(unittest.TestCase):
+
+    def setUp(self):
+
+        self.refv1 = lambda x, y, z: Vector3D(10 * x + 5 * y + z, 10 * x - 5 * y - 2 * z, x + y + z)
+        self.refv2 = lambda x, y, z: Vector3D(x * x + y * y + z * z, x * x - y * y - z * z, x * y * z)
+
+        self.vf1 = PythonVector3DFunction3D(self.refv1)
+        self.vf2 = PythonVector3DFunction3D(self.refv2)
+
+        self.ref1 = lambda x, y, z: 10 * x + 5 * y + z
+        self.ref2 = lambda x, y, z: x * x + y * y + z * z
+
+        self.f1 = PythonFloatFunction3D(self.ref1)
+        self.f2 = PythonFloatFunction3D(self.ref2)
+
+    def test_call(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(self.vf1(x, y, z), self.refv1(x, y, z), "vector3d.Function3D call did not match reference function value.")
+
+    def test_negate(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = -self.vf1
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r(x, y, z), -self.refv1(x, y, z), "vector3d.Function3D negate did not match reference function value.")
+
+    def test_add_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        c1 = Vector3D(3, 4, 5)
+        c2 = Vector3D(5, 12, 13)
+        r1 = c1 + self.vf1
+        r2 = self.vf1 + c2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), c1 + self.refv1(x, y, z), "vector3d.Function3D add Vector3D (V + vf()) did not match reference function value.")
+                    self.assertEqual(r2(x, y, z), self.refv1(x, y, z) + c2, "vector3d.Function3D add Vector3D (vf() + V) did not match reference function value.")
+
+    def test_sub_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        c1 = Vector3D(3, 4, 5)
+        c2 = Vector3D(5, 12, 13)
+        r1 = c1 - self.vf1
+        r2 = self.vf1 - c2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), c1 - self.refv1(x, y, z), "vector3d.Function3D subtract Vector3D (V - vf()) did not match reference function value.")
+                    self.assertEqual(r2(x, y, z), self.refv1(x, y, z) - c2, "vector3d.Function3D subtract Vector3D (vf() - V) did not match reference function value.")
+
+    def test_mul_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = self.vf1 * -7.8
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r(x, y, z), self.refv1(x, y, z) * -7.8, "vector3d.Function3D multiply Vector3D (vf() * V) did not match reference function value.")
+
+    def test_div_vector(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
+        r = self.vf1 / -7.8
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r(x, y, z), self.refv1(x, y, z) / -7.8, "vector3d.Function3D divide Vector3D (vf() / V) did not match reference function value.")
+
+        with self.assertRaises(TypeError, msg="TypeError not raised when dividing Vector3D by function."):
+            r = 5 / self.vf1
+
+    def test_richcmp_vector(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.refv1(x, y, z)
+                    not_ref_value = ref_value + Vector3D(*[ref + abs(ref) + 1 for ref in ref_value])
+                    self.assertEqual(
+                        (self.vf1 == ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D equals Vector3D (vf() == V) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value == self.vf1)(x, y, z), 1.0,
+                        msg="Vector3D equals vector3d.Function3D(V == vf()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 == not_ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D equals Vector3D (vf() == V) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (not_ref_value == self.vf1)(x, y, z), 0.0,
+                        msg="Vector3D equals vector3d.Function3D(V == vf()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != not_ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D not equals Vector3D (vf() != V) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (not_ref_value != self.vf1)(x, y, z), 1.0,
+                        msg="Vector3D not equals vector3d.Function3D(V != vf()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D not equals Vector3D (vf() != V) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value != self.vf1)(x, y, z), 0.0,
+                        msg="Vector3D not equals vector3d.Function3D(V != vf()) did not return false when it should."
+                    )
+
+    def test_add_function3d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 + self.vf2
+        r2 = self.refv1 + self.vf2
+        r3 = self.vf1 + self.refv2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), self.refv1(x, y, z) + self.refv2(x, y, z), "vector3d.Function3D add function (vf1() + vf2()) did not match reference function value.")
+                    self.assertEqual(r2(x, y, z), self.refv1(x, y, z) + self.refv2(x, y, z), "vector3d.Function3D add function (p1() + vf2()) did not match reference function value.")
+                    self.assertEqual(r3(x, y, z), self.refv1(x, y, z) + self.refv2(x, y, z), "vector3d.Function3D add function (vf1() + p2()) did not match reference function value.")
+
+    def test_sub_function3d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r = self.vf1 - self.vf2
+        r2 = self.refv1 - self.vf2
+        r3 = self.vf1 - self.refv2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r(x, y, z), self.refv1(x, y, z) - self.refv2(x, y, z), "vector3d.Function3D subtract function (vf1() - vf2()) did not match reference function value.")
+                    self.assertEqual(r2(x, y, z), self.refv1(x, y, z) - self.refv2(x, y, z), "vector3d.Function3D subtract function (p1() - vf2()) did not match reference function value.")
+                    self.assertEqual(r3(x, y, z), self.refv1(x, y, z) - self.refv2(x, y, z), "vector3d.Function3D subtract function (vf1() - p2()) did not match reference function value.")
+
+    def test_mul_function3d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 * self.f2
+        # No r2 = self.refv1 * self.f2, as p1() * f2() is treated as PythonFunction3D * Function3D
+        r2 = self.f1 * self.vf2
+        r3 = self.vf1 * self.ref2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), self.refv1(x, y, z) * self.ref2(x, y, z), "vector3d.Function3D multiply function (vf1() * f2()) did not match reference function value.")
+                    self.assertEqual(r2(x, y, z), self.ref1(x, y, z) * self.refv2(x, y, z), "vector3d.Function3D multiply function (f1() * vf2()) did not match reference function value.")
+                    self.assertEqual(r3(x, y, z), self.refv1(x, y, z) * self.ref2(x, y, z), "vector3d.Function3D multiply function (vf1() * p2()) did not match reference function value.")
+
+    def test_div_function3d(self):
+        v = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
+        r1 = self.vf1 / self.f2
+        # No r2 = self.refv1 / self.f2, as p1() / f2() is treated as PythonFunction3D / Function3D
+        r3 = self.vf1 / self.ref2
+        for x in v:
+            for y in v:
+                for z in v:
+                    self.assertEqual(r1(x, y, z), self.refv1(x, y, z) / self.ref2(x, y, z), msg="vector3d.Function3D divide function (vf1() / f2()) did not match reference function value.")
+                    self.assertEqual(r3(x, y, z), self.refv1(x, y, z) / self.ref2(x, y, z), msg="vector3d.Function3D divide function (vf1() / p2()) did not match reference function value.")
+
+        with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
+            r1(0, 0, 0)
+
+    def test_richcmp_function3d_callable(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.refv1
+
+                    def not_ref_value(x, y, z):
+                        ref = self.refv1(x, y, z)
+                        return ref + Vector3D(*[abs(r) + 1 for r in ref])
+
+                    self.assertEqual(
+                        (self.vf1 == ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D equals callable (vf1() == f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 == not_ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D equals callable (vf1() == f2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != not_ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D not equals callable (vf1() != f2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D not equals callable (vf1() != f2()) did not return false when it should."
+                    )
+
+    def test_richcmp_callable_function3d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.refv1
+
+                    def not_ref_value(x, y, z):
+                        ref = self.refv1(x, y, z)
+                        return ref + Vector3D(*[abs(r) + 1 for r in ref])
+
+                    self.assertEqual(
+                        (ref_value == self.vf1)(x, y, z), 1.0,
+                        msg="Callable equals vector3d.Function3D(f1() == vf2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (not_ref_value == self.vf1)(x, y, z), 0.0,
+                        msg="Callable equals vector3d.Function3D(f1() == vf2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (not_ref_value != self.vf1)(x, y, z), 1.0,
+                        msg="Callable not equals vector3d.Function3D(f1() != vf2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (ref_value != self.vf1)(x, y, z), 0.0,
+                        msg="Callable not equals vector3d.Function3D(f1() != vf2()) did not return false when it should."
+                    )
+
+    def test_richcmp_function3d_function3d(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    ref_value = self.vf1
+                    shift = Vector3D(*[abs(r) + 1 for r in self.refv1(x, y, z)])
+                    not_ref_value = self.vf1 + shift
+                    self.assertEqual(
+                        (self.vf1 == ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D equals vector3d.Function3D (vf1() == vf2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 == not_ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D equals vector3d.Function3D (vf1() == vf2()) did not return false when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != not_ref_value)(x, y, z), 1.0,
+                        msg="vector3d.Function3D not equals vector3d.Function3D (vf1() != vf2()) did not return true when it should."
+                    )
+                    self.assertEqual(
+                        (self.vf1 != ref_value)(x, y, z), 0.0,
+                        msg="vector3d.Function3D not equals vector3d.Function3D (vf1() != vf2()) did not return false when it should."
+                    )

--- a/raysect/core/math/function/vector3d/function3d/tests/test_constant.py
+++ b/raysect/core/math/function/vector3d/function3d/tests/test_constant.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+"""
+Unit tests for the Constant3D class.
+"""
+
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.vector3d.function3d.constant import Constant3D
+
+# TODO: expand tests to cover the cython interface
+class TestConstant3D(unittest.TestCase):
+
+    def test_constant(self):
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    vector = Vector3D(x, y, z)
+                    constant = Constant3D(vector)
+                    self.assertEqual(constant(500, -1.5, 8e4), vector,
+                                     "vector3d.Constant3D call did not match reference value.")

--- a/raysect/core/math/function/vector3d/function3d/tests/test_float_to_vector3d.py
+++ b/raysect/core/math/function/vector3d/function3d/tests/test_float_to_vector3d.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Copyright (c) 2014-2020, Dr Alex Meakins, Raysect Project
 # All rights reserved.
 #
@@ -29,6 +27,29 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+"""
+Unit tests for the Constant3D class.
+"""
+
+from math import sin
+import unittest
+from raysect.core.math import Vector3D
+from raysect.core.math.function.float import Arg3D, Sin3D
+from raysect.core.math.function.vector3d import FloatToVector3DFunction3D
+
+# TODO: expand tests to cover the cython interface
+class TestFloatToVector3D(unittest.TestCase):
+
+    def test_scalar_to_vector(self):
+        vx = 2 * Arg3D('z')  # Will be auto-wrapped to Constant3D
+        vy = Arg3D('y')
+        vz = Sin3D(Arg3D('x'))
+        fv = FloatToVector3DFunction3D(vx, vy, vz)
+        v = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
+        for x in v:
+            for y in v:
+                for z in v:
+                    expected = Vector3D(2 * z, y, sin(x))
+                    actual = fv(x, y, z)
+                    self.assertEqual(actual, expected,
+                                     "FloatToVector3DFunction3D call did not match reference value.")

--- a/raysect/core/math/function/vector3d/function3d/utility.pxd
+++ b/raysect/core/math/function/vector3d/function3d/utility.pxd
@@ -29,6 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.function.float.function3d.base cimport Function3D as FloatFunction3D
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+
+
+cdef class FloatToVector3DFunction3D(Function3D):
+    cdef FloatFunction3D _x, _y, _z

--- a/raysect/core/math/function/vector3d/function3d/utility.pyx
+++ b/raysect/core/math/function/vector3d/function3d/utility.pyx
@@ -29,6 +29,45 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from raysect.core.math.function.vector3d.function1d cimport *
-from raysect.core.math.function.vector3d.function2d cimport *
-from raysect.core.math.function.vector3d.function3d cimport *
+from raysect.core.math.vector cimport Vector3D, new_vector3d
+from raysect.core.math.function.float cimport autowrap_function3d as autowrap_floatfunction3d
+from .base cimport Function3D
+
+
+
+cdef class FloatToVector3DFunction3D(Function3D):
+    """
+    Combines three float.Function3D objects to produce a vector3d.Function3D.
+
+    The three float.Function3D objects correspond to the x, y and z components
+    of the resulting vector object.
+
+    :param float.Function3D x_function: the Vx(x, y, z) 3d function.
+    :param float.Function3D y_function: the Vy(x, y, z) 3d function.
+    :param float.Function3D z_function: the Vz(x, y, z) 3d function.
+
+    .. code-block:: pycon
+
+       >>> from raysect.core.math.function.float import Sqrt3D, Exp3D, Arg3D
+       >>> from raysect.core.math.function.vector3d import FloatToVector3DFunction3D
+       >>>
+       >>> vx = 1  # Will be auto-wrapped to Constant3D(1)
+       >>> vy = Arg3D('y')
+       >>> vz = Sqrt3D(Arg3D('x'))
+       >>>
+       >>> fv = FloatToVector3DFunction3D(vx, vy, vz)
+       >>> fv(4.0, 6.2)
+       Vector3D(1.0, 6.2, 2.0)
+    """
+
+    def __init__(self, object x_function, object y_function, object z_function):
+        self._x = autowrap_floatfunction3d(x_function)
+        self._y = autowrap_floatfunction3d(y_function)
+        self._z = autowrap_floatfunction3d(z_function)
+
+    cdef Vector3D evaluate(self, double x, double y, double z):
+        cdef double vx, vy, vz
+        vx = self._x.evaluate(x, y, z)
+        vy = self._y.evaluate(x, y, z)
+        vz = self._z.evaluate(x, y, z)
+        return new_vector3d(vx, vy, vz)


### PR DESCRIPTION
Replicate the 2D vector3d function framework for classes which except 1 and 3 arguments.

This PR was essentially an exercise in find, sed and bulk tab insertion, but I don't think I've missed anything. The tests pass, so I think all that's left is to update the HTML documentation for all the vector3d classes.