### PR TITLE
Add Vector3D function imports to higher level namespace.

### DIFF
--- a/raysect/core/math/function/vector3d/function1d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/function1d/__init__.pxd
@@ -29,4 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from raysect.core.math.function.vector3d.function1d.base cimport Function1D
+from raysect.core.math.function.vector3d.function1d.constant cimport Constant1D
+from raysect.core.math.function.vector3d.function1d.autowrap cimport autowrap_function1d
 from raysect.core.math.function.vector3d.function1d.utility cimport *

--- a/raysect/core/math/function/vector3d/function2d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/function2d/__init__.pxd
@@ -29,4 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from raysect.core.math.function.vector3d.function2d.base cimport Function2D
+from raysect.core.math.function.vector3d.function2d.constant cimport Constant2D
+from raysect.core.math.function.vector3d.function2d.autowrap cimport autowrap_function2d
 from raysect.core.math.function.vector3d.function2d.utility cimport *

--- a/raysect/core/math/function/vector3d/function3d/__init__.pxd
+++ b/raysect/core/math/function/vector3d/function3d/__init__.pxd
@@ -29,4 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from raysect.core.math.function.vector3d.function3d.base cimport Function3D
+from raysect.core.math.function.vector3d.function3d.constant cimport Constant3D
+from raysect.core.math.function.vector3d.function3d.autowrap cimport autowrap_function3d
 from raysect.core.math.function.vector3d.function3d.utility cimport *


### PR DESCRIPTION
Bring imports up to `raysect.core.math.function.vector3d`, so they
match those from `raysect.core.math.function.float`.

Fixes #361 