### PR TITLE
Update tetrahedra_mesh_emission.py to support the new version of Py3DViewer

### DIFF
--- a/demos/materials/tetrahedra_mesh_emission.py
+++ b/demos/materials/tetrahedra_mesh_emission.py
@@ -29,7 +29,11 @@ class UnityEmitter(InhomogeneousVolumeEmitter):
 
 # Rabbit tetrahedra mesh emitter
 mesh = Tetmesh(os.path.join(BASE_PATH, "../resources/stanford_bunny.mesh"))
-tetra = Discrete3DMesh(mesh.vertices, mesh.tets, np.ones((mesh.num_tets)), False, 0)
+
+try:
+    tetra = Discrete3DMesh(mesh.vertices, mesh.polys, np.ones((mesh.num_polys)), False, 0)
+except AttributeError:  # for backward compatibility with older versions of Py3DViewer
+    tetra = Discrete3DMesh(mesh.vertices, mesh.tets, np.ones((mesh.num_tets)), False, 0)
 
 # scene
 world = World()


### PR DESCRIPTION
This fixes #374 by updating the tetrahedra_mesh_emission.py demo. The correct `Py3DViewer.Tetmesh` attributes are now used in both new and old versions of Py3DViewer.