### PR TITLE
Make the display_progress attribute of SpectralPowerPipeline0D public (issue #385).

### DIFF
--- a/raysect/optical/observer/pipeline/spectral/power.pxd
+++ b/raysect/optical/observer/pipeline/spectral/power.pxd
@@ -43,7 +43,7 @@ cdef class SpectralPowerPipeline0D(Pipeline0D):
         readonly int bins
         readonly double min_wavelength, max_wavelength, delta_wavelength
         readonly np.ndarray wavelengths
-        bint display_progress
+        public bint display_progress
         object _display_figure
         bint _quiet
 


### PR DESCRIPTION
This fixes #385 by declaring the `display_progress` attribute of `SpectralPowerPipeline0D` public.