### PR TITLE
Make the attribute 'name' puplic for all pipelines

### DIFF
--- a/raysect/optical/observer/pipeline/bayer.pxd
+++ b/raysect/optical/observer/pipeline/bayer.pxd
@@ -35,7 +35,7 @@ from raysect.core.math cimport StatsArray2D
 cdef class BayerPipeline2D(Pipeline2D):
 
     cdef:
-        str name
+        public str name
         public SpectralFunction red_filter, green_filter, blue_filter
         tuple _bayer_mosaic
         public bint display_progress

--- a/raysect/optical/observer/pipeline/mono/power.pxd
+++ b/raysect/optical/observer/pipeline/mono/power.pxd
@@ -37,7 +37,7 @@ from raysect.optical.observer.base.sampler cimport FrameSampler2D
 cdef class PowerPipeline0D(Pipeline0D):
 
     cdef:
-        str name
+        public str name
         public SpectralFunction filter
         public bint accumulate
         readonly StatsBin value
@@ -49,7 +49,7 @@ cdef class PowerPipeline0D(Pipeline0D):
 cdef class PowerPipeline1D(Pipeline1D):
 
     cdef:
-        str name
+        public str name
         public SpectralFunction filter
         public bint accumulate
         readonly StatsArray1D frame
@@ -63,7 +63,7 @@ cdef class PowerPipeline1D(Pipeline1D):
 cdef class PowerPipeline2D(Pipeline2D):
 
     cdef:
-        str name
+        public str name
         public SpectralFunction filter
         public bint display_progress
         double _display_timer

--- a/raysect/optical/observer/pipeline/rgb.pxd
+++ b/raysect/optical/observer/pipeline/rgb.pxd
@@ -35,7 +35,7 @@ from raysect.core.math cimport StatsArray3D, StatsArray1D
 cdef class RGBPipeline2D(Pipeline2D):
 
     cdef:
-        str name
+        public str name
         public bint display_progress
         double _display_timer
         double _display_update_time


### PR DESCRIPTION
This fixes issue #387 by declaring the attribute `name` of `PowerPipeline#D`, `BayerPipeline2D` and `RGBPipeline2D` public.