### PR TITLE
Add imported module lines

### DIFF
--- a/raysect/core/math/function/float/function3d/__init__.pxd
+++ b/raysect/core/math/function/float/function3d/__init__.pxd
@@ -33,5 +33,6 @@ from raysect.core.math.function.float.function3d.base cimport Function3D
 from raysect.core.math.function.float.function3d.constant cimport Constant3D
 from raysect.core.math.function.float.function3d.blend cimport Blend3D
 from raysect.core.math.function.float.function3d.autowrap cimport autowrap_function3d
+from raysect.core.math.function.float.function3d.interpolate cimport *
 from raysect.core.math.function.float.function3d.arg cimport Arg3D
 from raysect.core.math.function.float.function3d.cmath cimport *

--- a/raysect/core/math/function/float/function3d/__init__.py
+++ b/raysect/core/math/function/float/function3d/__init__.py
@@ -32,5 +32,6 @@
 from .base import Function3D
 from .constant import Constant3D
 from .blend import Blend3D
+from .interpolate import *
 from .arg import Arg3D
 from .cmath import *


### PR DESCRIPTION
Added the interpolate module into __init__.py because I forgot to implement them in the previous PR.