### PR TITLE
Fix wrong typing

### DIFF
--- a/raysect/optical/observer/pipeline/spectral/power.pyx
+++ b/raysect/optical/observer/pipeline/spectral/power.pyx
@@ -387,7 +387,7 @@ cdef class SpectralPowerPipeline2D(Pipeline2D):
         ) = state
 
         # initialise internal state
-        self._pixels = 0
+        self._pixels = None
         self._samples = 0
         self._spectral_slices = None
 


### PR DESCRIPTION
This should fixt the wrong typing in __setstate__ and remove bug reported in #411 

@CnlPepper would it be possible to apply this fix for Raysect 0.7.0, which is still what Cherab-master is using?