### PR TITLE
Fix set_window_title() error with Matplotlib 3.6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Bug fixes:
 * extract_rotation() now returns the correct values for yaw, pitch and roll in the z axis up coordinate system (Jamie Bayne).
 * The quiet parameter is now correctly handled by Observer1D and Observer2D.
 * Fixed Ray.extinction_min_depth bug that prevented the attribute being set to 1.
+* Fixed Matplotlib 3.6 incompatibility issue. (#383)
 
 
 Release 0.8.0 (26 May 2022)

--- a/raysect/optical/observer/pipeline/bayer.pyx
+++ b/raysect/optical/observer/pipeline/bayer.pyx
@@ -473,14 +473,15 @@ cdef class BayerPipeline2D(Pipeline2D):
 
         # create a fresh figure if the existing figure window has gone missing
         if not self._display_figure or not plt.fignum_exists(self._display_figure.number):
-            self._display_figure = plt.figure(facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
+            self._display_figure = plt.figure(self.name, facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
         fig = self._display_figure
 
-        # set window title
-        if status:
-            fig.canvas.set_window_title("{} - {}".format(self.name, status))
-        else:
-            fig.canvas.set_window_title(self.name)
+        # update window title if possible
+        if fig.canvas.manager is not None:
+            if status:
+                fig.canvas.manager.set_window_title("{} - {}".format(self.name, status))
+            else:
+                fig.canvas.manager.set_window_title(self.name)
 
         # populate figure
         fig.clf()

--- a/raysect/optical/observer/pipeline/mono/power.pyx
+++ b/raysect/optical/observer/pipeline/mono/power.pyx
@@ -635,14 +635,15 @@ cdef class PowerPipeline2D(Pipeline2D):
 
         # create a fresh figure if the existing figure window has gone missing
         if not self._display_figure or not plt.fignum_exists(self._display_figure.number):
-            self._display_figure = plt.figure(facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
+            self._display_figure = plt.figure(self.name, facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
         fig = self._display_figure
 
-        # set window title
-        if status:
-            fig.canvas.set_window_title("{} - {}".format(self.name, status))
-        else:
-            fig.canvas.set_window_title(self.name)
+        # update window title if possible
+        if fig.canvas.manager is not None:
+            if status:
+                fig.canvas.manager.set_window_title("{} - {}".format(self.name, status))
+            else:
+                fig.canvas.manager.set_window_title(self.name)
 
         # populate figure
         fig.clf()

--- a/raysect/optical/observer/pipeline/rgb.pyx
+++ b/raysect/optical/observer/pipeline/rgb.pyx
@@ -377,14 +377,15 @@ cdef class RGBPipeline2D(Pipeline2D):
 
         # create a fresh figure if the existing figure window has gone missing
         if not self._display_figure or not plt.fignum_exists(self._display_figure.number):
-            self._display_figure = plt.figure(facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
+            self._display_figure = plt.figure(self.name, facecolor=(0.5, 0.5, 0.5), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
         fig = self._display_figure
 
-        # set window title
-        if status:
-            fig.canvas.set_window_title("{} - {}".format(self.name, status))
-        else:
-            fig.canvas.set_window_title(self.name)
+        # update window title if possible
+        if fig.canvas.manager is not None:
+            if status:
+                fig.canvas.manager.set_window_title("{} - {}".format(self.name, status))
+            else:
+                fig.canvas.manager.set_window_title(self.name)
 
         # populate figure
         fig.clf()

--- a/raysect/optical/observer/pipeline/spectral/power.pyx
+++ b/raysect/optical/observer/pipeline/spectral/power.pyx
@@ -177,11 +177,12 @@ cdef class SpectralPowerPipeline0D(Pipeline0D):
 
         # create a fresh figure if the existing figure window has gone missing
         if not self._display_figure or not plt.fignum_exists(self._display_figure.number):
-            self._display_figure = plt.figure(facecolor=(1, 1, 1), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
+            self._display_figure = plt.figure(self.name, facecolor=(1, 1, 1), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
         fig = self._display_figure
 
-        # set window title
-        fig.canvas.set_window_title(self.name)
+        # update window title if possible
+        if fig.canvas.manager is not None:
+            fig.canvas.manager.set_window_title(self.name)
 
         fig.clf()
         plt.plot(self.wavelengths, self.samples.mean[:], color=(0, 0, 1))

--- a/raysect/optical/observer/pipeline/spectral/radiance.pyx
+++ b/raysect/optical/observer/pipeline/spectral/radiance.pyx
@@ -84,11 +84,12 @@ cdef class SpectralRadiancePipeline0D(SpectralPowerPipeline0D):
 
         # create a fresh figure if the existing figure window has gone missing
         if not self._display_figure or not plt.fignum_exists(self._display_figure.number):
-            self._display_figure = plt.figure(facecolor=(1, 1, 1), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
+            self._display_figure = plt.figure(self.name, facecolor=(1, 1, 1), figsize=_DISPLAY_SIZE, dpi=_DISPLAY_DPI)
         fig = self._display_figure
 
-        # set window title
-        fig.canvas.set_window_title(self.name)
+        # update window title if possible
+        if fig.canvas.manager is not None:
+            fig.canvas.manager.set_window_title(self.name)
 
         fig.clf()
         plt.plot(self.wavelengths, self.samples.mean[:], color=(0, 0, 1))


### PR DESCRIPTION
This is a hot fix for #383. The deprecated `set_window_title()` `canvas` method has been replaced with the `manager` method. The window title will not update if the `canvas` does not have a `manager`.

If possible, it would be great to have this fix in Raysect 0.7.x as well.